### PR TITLE
refactor: Visual Consistency Phase 1

### DIFF
--- a/components/blog/blog-card.tsx
+++ b/components/blog/blog-card.tsx
@@ -16,7 +16,7 @@ export function BlogCard({ post }: BlogCardProps) {
 
     return (
         <Link href={`/blog/${post._meta.path}`} className="group relative block">
-            <article className="relative flex h-full flex-col overflow-hidden rounded-xl border border-border/60 bg-card p-5 shadow-sm transition-all group-hover:shadow-md group-hover:scale-[1.02]">
+            <article className="relative flex h-full flex-col overflow-hidden rounded-xl border border-border/60 bg-card p-5 shadow-sm transition-all group-hover:border-sky-500 group-hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]">
                 {post.publish === false && (
                     <div className="absolute inset-0 z-20 flex items-center justify-center rounded-xl bg-background/60 backdrop-blur-[2px]">
                         <span className="text-3xl font-bold text-destructive/40">Unpublished</span>

--- a/components/doc/doc-index-card.tsx
+++ b/components/doc/doc-index-card.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Link from 'next/link';
 import { FileText, ExternalLink, LucideIcon } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
 
 export enum DocIndexItemType {
     Internal, // Displays a doc page icon
@@ -28,11 +29,7 @@ export function DocIndexCard(props: DocIndexCardProps) {
     return (
         <div className="mb-6 mt-4">
             <div className="mb-4 flex items-center gap-3">
-                {Icon && (
-                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-emerald-600 text-white shadow-sm">
-                        <Icon className="h-5 w-5" />
-                    </div>
-                )}
+                {Icon && <IconBadge icon={Icon} variant="default" size="md" />}
                 <div>
                     <h2 className="text-xl font-bold tracking-tight text-foreground">{props.title}</h2>
                     {props.description && <p className="text-sm text-muted-foreground">{props.description}</p>}
@@ -44,7 +41,7 @@ export function DocIndexCard(props: DocIndexCardProps) {
                     const isExternal = item.type === DocIndexItemType.External;
                     return (
                         <Link key={index} href={item.href} target={isExternal ? '_blank' : undefined} className="group block">
-                            <div className="flex h-full items-start gap-4 rounded-xl border border-border/60 bg-card p-5 shadow-sm transition-all group-hover:shadow-md group-hover:scale-[1.02]">
+                            <div className="flex h-full items-start gap-4 rounded-xl border border-border/60 bg-card p-5 shadow-sm transition-all group-hover:border-sky-500 group-hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]">
                                 <div className="mt-0.5 flex-shrink-0 text-muted-foreground transition-colors group-hover:text-sky-600 dark:group-hover:text-sky-400">
                                     <ItemIcon className="h-5 w-5" />
                                 </div>

--- a/components/navigation/mobile-nav.tsx
+++ b/components/navigation/mobile-nav.tsx
@@ -53,7 +53,7 @@ export function MobileNav() {
                                             {item.href ? (
                                                 <MobileLink href={item.href} onOpenChange={setOpen} className="text-muted-foreground">
                                                     {item.title}
-                                                    {item.label && <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">{item.label}</span>}
+                                                    {item.label && <span className="ml-2 rounded-md bg-sky-500 px-1.5 py-0.5 text-xs leading-none text-white no-underline group-hover:no-underline">{item.label}</span>}
                                                 </MobileLink>
                                             ) : (
                                                 item.title

--- a/components/navigation/sidebar-nav.tsx
+++ b/components/navigation/sidebar-nav.tsx
@@ -49,7 +49,7 @@ export function DocsSidebarNavItems({ items, pathname }: DocsSidebarNavItemsProp
             return (
                 <Link key={index} href={item.href} className={cn('group flex w-full items-center rounded-md border border-transparent px-2 py-1 hover:underline', pathname === item.href ? 'font-medium text-foreground' : 'text-muted-foreground')} target={item.external ? '_blank' : ''} rel={item.external ? 'noreferrer' : ''}>
                     {item.title}
-                    {item.label && <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">{item.label}</span>}
+                    {item.label && <span className="ml-2 rounded-md bg-sky-500 px-1.5 py-0.5 text-xs leading-none text-white no-underline group-hover:no-underline">{item.label}</span>}
                 </Link>
             );
         } else {

--- a/components/navigation/site-footer.tsx
+++ b/components/navigation/site-footer.tsx
@@ -3,6 +3,7 @@ import { buildMetadata } from '@/lib/version';
 import React from 'react';
 import Link from 'next/link';
 import { Radio, Github, Linkedin, Facebook, Instagram } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
 
 const socialLinks = [
     { href: siteConfig.links.discord, icon: Radio, label: 'Discord' },
@@ -30,9 +31,7 @@ export function SiteFooter() {
                     {/* Brand */}
                     <div className="sm:col-span-2">
                         <div className="flex items-center gap-3">
-                            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-emerald-600 text-white shadow-sm">
-                                <Radio className="h-5 w-5" />
-                            </div>
+                            <IconBadge icon={Radio} variant="default" size="sm" />
                             <span className="text-lg font-bold text-foreground">{siteConfig.name}</span>
                         </div>
                         <p className="mt-3 max-w-sm text-sm text-muted-foreground">{siteConfig.description}</p>

--- a/components/product/guitar-page.tsx
+++ b/components/product/guitar-page.tsx
@@ -13,6 +13,7 @@ import { GuitarControls } from './guitar-controls';
 import { GuitarPurchase } from './guitar-purchase';
 import { GuitarRelatedPosts } from './guitar-related-posts';
 import { Guitar as GuitarIcon, Info, BookOpen } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
 
 interface GuitarPageProps {
     guitar: Guitar;
@@ -37,14 +38,12 @@ export function GuitarPage({ guitar, Description }: GuitarPageProps) {
             <div className="space-y-6">
                 {/* Enhanced Header Section */}
                 <div className="relative isolate overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-slate-50 via-white to-slate-50 px-6 py-8 shadow-lg ring-1 ring-black/5 dark:border-slate-800 dark:from-slate-950/70 dark:via-slate-900/50 dark:to-slate-950/70 dark:ring-white/10">
-                    <div className="absolute inset-0 -z-10 bg-gradient-to-br from-blue-100/50 via-transparent to-purple-100/50 dark:from-blue-900/10 dark:via-transparent dark:to-purple-900/10" />
-                    <div className="absolute -right-20 top-0 -z-10 h-64 w-64 rounded-full bg-blue-400/20 blur-3xl dark:bg-blue-500/10" />
-                    <div className="absolute -left-20 bottom-0 -z-10 h-64 w-64 rounded-full bg-purple-400/20 blur-3xl dark:bg-purple-500/10" />
+                    <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-100/50 via-transparent to-indigo-100/50 dark:from-sky-900/10 dark:via-transparent dark:to-indigo-900/10" />
+                    <div className="absolute -right-20 top-0 -z-10 h-64 w-64 rounded-full bg-sky-400/20 blur-3xl dark:bg-sky-500/10" />
+                    <div className="absolute -left-20 bottom-0 -z-10 h-64 w-64 rounded-full bg-indigo-400/20 blur-3xl dark:bg-indigo-500/10" />
                     <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                         <div className="flex items-center gap-4">
-                            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg">
-                                <GuitarIcon className="h-6 w-6 text-white" />
-                            </div>
+                            <IconBadge icon={GuitarIcon} variant="guitar" size="lg" />
                             <div>
                                 <h1 className={cn('scroll-m-20 text-3xl font-bold tracking-tight bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent dark:from-slate-100 dark:to-slate-300')}>{guitar.name}</h1>
                                 <Badge variant="secondary" className="mt-2">
@@ -62,7 +61,7 @@ export function GuitarPage({ guitar, Description }: GuitarPageProps) {
                     {/* Left: Images */}
                     <div>
                         {guitar.images.length > 0 && (
-                            <Card className="border-2 shadow-md hover:shadow-lg transition-shadow">
+                            <Card className="border border-border shadow-md hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150">
                                 <CardContent className="p-6">
                                     <GuitarImageGallery images={guitar.images} alt={guitar.name} />
                                 </CardContent>
@@ -72,20 +71,20 @@ export function GuitarPage({ guitar, Description }: GuitarPageProps) {
 
                     {/* Right: Compact specs, pickups, controls */}
                     <div className="space-y-4">
-                        <Card className="border-2 shadow-md hover:shadow-lg transition-shadow">
+                        <Card className="border border-border shadow-md hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150">
                             <GuitarSpecs guitar={guitar} />
                         </Card>
-                        <Card className="border-2 shadow-md hover:shadow-lg transition-shadow">
+                        <Card className="border border-border shadow-md hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150">
                             <GuitarPickups guitar={guitar} />
                         </Card>
-                        <Card className="border-2 shadow-md hover:shadow-lg transition-shadow">
+                        <Card className="border border-border shadow-md hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150">
                             <GuitarControls guitar={guitar} />
                         </Card>
                     </div>
                 </div>
 
                 {/* Description below the fold */}
-                <Card className="border-2 shadow-md bg-gradient-to-br from-slate-50/50 to-white dark:from-slate-900/50 dark:to-slate-950/50">
+                <Card className="border border-border shadow-md bg-gradient-to-br from-slate-50/50 to-white dark:from-slate-900/50 dark:to-slate-950/50">
                     <CardHeader className="pb-3">
                         <div className="flex items-center gap-2">
                             <Info className="h-5 w-5 text-primary" />
@@ -109,7 +108,7 @@ export function GuitarPage({ guitar, Description }: GuitarPageProps) {
 
                 {/* Related posts */}
                 {relatedPosts.length > 0 && (
-                    <Card className="border-2 shadow-md bg-gradient-to-br from-blue-50/50 to-purple-50/50 dark:from-blue-950/20 dark:to-purple-950/20">
+                    <Card className="border border-border shadow-md bg-gradient-to-br from-sky-50/50 to-indigo-50/50 dark:from-sky-950/20 dark:to-indigo-950/20">
                         <CardHeader className="pb-3">
                             <div className="flex items-center gap-2">
                                 <BookOpen className="h-5 w-5 text-primary" />

--- a/components/product/ham-radio-kit-page.tsx
+++ b/components/product/ham-radio-kit-page.tsx
@@ -10,6 +10,7 @@ import { GuitarImageGallery } from './guitar-image-gallery';
 import { ProductRelatedPosts } from './product-related-posts';
 import { ProductPurchase } from './product-purchase';
 import { Radio, Info, BookOpen, Zap, CheckCircle2 } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
 
 interface HamRadioKitPageProps {
     product: Product;
@@ -38,14 +39,12 @@ export function HamRadioKitPage({ product, Description }: HamRadioKitPageProps) 
             <div className="space-y-6">
                 {/* Enhanced Header Section */}
                 <div className="relative isolate overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-slate-50 via-white to-slate-50 px-6 py-8 shadow-lg ring-1 ring-black/5 dark:border-slate-800 dark:from-slate-950/70 dark:via-slate-900/50 dark:to-slate-950/70 dark:ring-white/10">
-                    <div className="absolute inset-0 -z-10 bg-gradient-to-br from-amber-100/50 via-transparent to-orange-100/50 dark:from-amber-900/10 dark:via-transparent dark:to-orange-900/10" />
-                    <div className="absolute -right-20 top-0 -z-10 h-64 w-64 rounded-full bg-amber-400/20 blur-3xl dark:bg-amber-500/10" />
-                    <div className="absolute -left-20 bottom-0 -z-10 h-64 w-64 rounded-full bg-orange-400/20 blur-3xl dark:bg-orange-500/10" />
+                    <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-100/50 via-transparent to-emerald-100/50 dark:from-sky-900/10 dark:via-transparent dark:to-emerald-900/10" />
+                    <div className="absolute -right-20 top-0 -z-10 h-64 w-64 rounded-full bg-sky-400/20 blur-3xl dark:bg-sky-500/10" />
+                    <div className="absolute -left-20 bottom-0 -z-10 h-64 w-64 rounded-full bg-emerald-400/20 blur-3xl dark:bg-emerald-500/10" />
                     <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                         <div className="flex items-center gap-4">
-                            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-amber-500 to-orange-600 shadow-lg">
-                                <Radio className="h-6 w-6 text-white" />
-                            </div>
+                            <IconBadge icon={Radio} variant="default" size="lg" />
                             <div>
                                 <h1 className={cn('scroll-m-20 text-3xl font-bold tracking-tight bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent dark:from-slate-100 dark:to-slate-300')}>{product.name}</h1>
                                 <Badge variant="secondary" className="mt-2">
@@ -59,7 +58,7 @@ export function HamRadioKitPage({ product, Description }: HamRadioKitPageProps) 
 
                 {/* Images */}
                 {product.images.length > 0 && (
-                    <Card className="border-2 shadow-md hover:shadow-lg transition-shadow">
+                    <Card className="border border-border shadow-md hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150">
                         <CardContent className="p-6">
                             <GuitarImageGallery images={product.images} alt={product.name} />
                         </CardContent>
@@ -68,7 +67,7 @@ export function HamRadioKitPage({ product, Description }: HamRadioKitPageProps) 
 
                 {/* Key Features - only for dummy load */}
                 {isDummyLoad && (
-                    <Card className="border-2 shadow-md hover:shadow-lg transition-shadow bg-gradient-to-br from-amber-50/50 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/20">
+                    <Card className="border border-border shadow-md hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150 bg-gradient-to-br from-sky-50/50 to-emerald-50/50 dark:from-sky-950/20 dark:to-emerald-950/20">
                         <CardHeader className="pb-3">
                             <div className="flex items-center gap-2">
                                 <Zap className="h-5 w-5 text-primary" />
@@ -104,7 +103,7 @@ export function HamRadioKitPage({ product, Description }: HamRadioKitPageProps) 
 
                 {/* Specifications - only for dummy load */}
                 {isDummyLoad && (
-                    <Card className="border-2 shadow-md hover:shadow-lg transition-shadow">
+                    <Card className="border border-border shadow-md hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150">
                         <CardHeader className="pb-3">
                             <div className="flex items-center gap-2">
                                 <CheckCircle2 className="h-5 w-5 text-primary" />
@@ -140,7 +139,7 @@ export function HamRadioKitPage({ product, Description }: HamRadioKitPageProps) 
                 )}
 
                 {/* Description */}
-                <Card className="border-2 shadow-md bg-gradient-to-br from-slate-50/50 to-white dark:from-slate-900/50 dark:to-slate-950/50">
+                <Card className="border border-border shadow-md bg-gradient-to-br from-slate-50/50 to-white dark:from-slate-900/50 dark:to-slate-950/50">
                     <CardHeader className="pb-3">
                         <div className="flex items-center gap-2">
                             <Info className="h-5 w-5 text-primary" />
@@ -164,7 +163,7 @@ export function HamRadioKitPage({ product, Description }: HamRadioKitPageProps) 
 
                 {/* Related posts */}
                 {relatedPosts.length > 0 && (
-                    <Card className="border-2 shadow-md bg-gradient-to-br from-amber-50/50 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/20">
+                    <Card className="border border-border shadow-md bg-gradient-to-br from-sky-50/50 to-emerald-50/50 dark:from-sky-950/20 dark:to-emerald-950/20">
                         <CardHeader className="pb-3">
                             <div className="flex items-center gap-2">
                                 <BookOpen className="h-5 w-5 text-primary" />

--- a/components/product/product-teaser-card.tsx
+++ b/components/product/product-teaser-card.tsx
@@ -17,7 +17,7 @@ export function ProductTeaserCard({ product, category }: ProductTeaserCardProps)
 
     return (
         <Link href={`/products/${category}/${product.slug}`}>
-            <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+            <Card className="cursor-pointer hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150 h-full">
                 <CardContent className="p-4">
                     <div className="flex gap-3">
                         <div className="relative w-24 h-24 flex-shrink-0 overflow-hidden rounded-md">

--- a/components/shared/cta-banner.tsx
+++ b/components/shared/cta-banner.tsx
@@ -10,7 +10,7 @@ interface CTABannerProps {
 
 export function CTABanner({ title, description, variant = 'default', children }: CTABannerProps) {
     return (
-        <div className={cn('relative isolate overflow-hidden rounded-2xl px-6 py-10 text-center md:px-12', variant === 'default' && 'bg-muted/50', variant === 'gradient' && 'bg-gradient-to-br from-sky-100 via-white to-emerald-100 dark:from-slate-900 dark:via-slate-950 dark:to-indigo-900')}>
+        <div className={cn('relative isolate overflow-hidden rounded-2xl px-6 py-10 text-center md:px-12', variant === 'default' && 'bg-muted/50', variant === 'gradient' && 'bg-gradient-to-br from-sky-100 via-white to-emerald-100 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900')}>
             {variant === 'gradient' && <div className="absolute -right-16 top-0 -z-10 h-48 w-48 rounded-full bg-sky-400/20 blur-3xl dark:bg-sky-500/10" />}
             <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">{title}</h2>
             <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">{description}</p>

--- a/components/shared/feature-grid.tsx
+++ b/components/shared/feature-grid.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { LucideIcon } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
 
 interface FeatureCardProps {
     icon: LucideIcon;
@@ -10,9 +11,9 @@ interface FeatureCardProps {
 
 export function FeatureCard({ icon: Icon, title, description }: FeatureCardProps) {
     return (
-        <div className="group rounded-xl border border-border/60 bg-card p-6 shadow-sm transition-all hover:shadow-md hover:scale-[1.02]">
-            <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-emerald-600 text-white shadow-sm">
-                <Icon className="h-5 w-5" />
+        <div className="group rounded-xl border border-border/60 bg-card p-6 shadow-sm transition-all hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]">
+            <div className="mb-4">
+                <IconBadge icon={Icon} variant="default" size="md" />
             </div>
             <h3 className="font-semibold text-foreground">{title}</h3>
             <p className="mt-2 text-sm text-muted-foreground">{description}</p>

--- a/components/shared/icon-badge.test.tsx
+++ b/components/shared/icon-badge.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { IconBadge } from './icon-badge';
+import { Radio } from 'lucide-react';
+
+describe('IconBadge', () => {
+	it('applies default sky→emerald gradient', () => {
+		const { container } = render(<IconBadge icon={Radio} />);
+		const div = container.firstChild as HTMLElement;
+		expect(div.className).toContain('from-sky-500');
+		expect(div.className).toContain('to-emerald-600');
+	});
+
+	it('applies guitar sky→indigo gradient', () => {
+		const { container } = render(<IconBadge icon={Radio} variant="guitar" />);
+		const div = container.firstChild as HTMLElement;
+		expect(div.className).toContain('from-sky-500');
+		expect(div.className).toContain('to-indigo-600');
+	});
+
+	it('applies sm size classes', () => {
+		const { container } = render(<IconBadge icon={Radio} size="sm" />);
+		const div = container.firstChild as HTMLElement;
+		expect(div.className).toContain('h-9');
+		expect(div.className).toContain('w-9');
+		expect(div.className).toContain('rounded-lg');
+	});
+
+	it('applies md size classes by default', () => {
+		const { container } = render(<IconBadge icon={Radio} />);
+		const div = container.firstChild as HTMLElement;
+		expect(div.className).toContain('h-10');
+		expect(div.className).toContain('w-10');
+		expect(div.className).toContain('rounded-lg');
+	});
+
+	it('applies lg size classes', () => {
+		const { container } = render(<IconBadge icon={Radio} size="lg" />);
+		const div = container.firstChild as HTMLElement;
+		expect(div.className).toContain('h-12');
+		expect(div.className).toContain('w-12');
+		expect(div.className).toContain('rounded-xl');
+	});
+
+	it('renders the icon', () => {
+		const { container } = render(<IconBadge icon={Radio} />);
+		expect(container.querySelector('svg')).toBeInTheDocument();
+	});
+});

--- a/components/shared/icon-badge.tsx
+++ b/components/shared/icon-badge.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface IconBadgeProps {
+	icon: React.ElementType;
+	variant?: 'default' | 'guitar';
+	size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeClasses = {
+	sm: { wrapper: 'h-9 w-9 rounded-lg', icon: 'h-4 w-4' },
+	md: { wrapper: 'h-10 w-10 rounded-lg', icon: 'h-5 w-5' },
+	lg: { wrapper: 'h-12 w-12 rounded-xl', icon: 'h-6 w-6' },
+};
+
+const variantClasses = {
+	default: 'from-sky-500 to-emerald-600',
+	guitar: 'from-sky-500 to-indigo-600',
+};
+
+export function IconBadge({ icon: Icon, variant = 'default', size = 'md' }: IconBadgeProps) {
+	return (
+		<div className={cn('flex items-center justify-center bg-gradient-to-br shadow-sm text-white', sizeClasses[size].wrapper, variantClasses[variant])}>
+			<Icon className={sizeClasses[size].icon} />
+		</div>
+	);
+}

--- a/components/shared/page-hero.tsx
+++ b/components/shared/page-hero.tsx
@@ -14,7 +14,7 @@ interface PageHeroProps {
 export function PageHero({ badge, title, description, secondaryText, actions, children, footer }: PageHeroProps) {
     return (
         <section className="relative isolate overflow-hidden rounded-3xl border border-border/60 bg-white/80 px-6 py-12 shadow-lg ring-1 ring-black/5 dark:border-slate-800 dark:bg-slate-950/70 dark:ring-white/10 md:px-12">
-            <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-100 via-white to-emerald-100 opacity-90 dark:from-slate-900 dark:via-slate-950 dark:to-indigo-900" />
+            <div className="absolute inset-0 -z-10 bg-gradient-to-br from-sky-100 via-white to-emerald-100 opacity-90 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900" />
             <div className="absolute -right-24 top-10 -z-10 h-64 w-64 rounded-full bg-sky-400/30 blur-3xl dark:bg-sky-500/10" />
             <div className="absolute -left-24 bottom-0 -z-10 h-72 w-72 rounded-full bg-emerald-300/30 blur-3xl dark:bg-emerald-500/10" />
             <div className="mx-auto flex max-w-6xl flex-col gap-12 lg:flex-row lg:items-center">

--- a/components/shared/section.tsx
+++ b/components/shared/section.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { LucideIcon } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
 
 interface SectionProps {
     background?: 'default' | 'gradient' | 'muted';
@@ -13,12 +14,12 @@ interface SectionProps {
 
 export function Section({ background = 'default', title, description, icon: Icon, children, className }: SectionProps) {
     return (
-        <section className={cn('rounded-2xl px-6 py-10 md:px-10', background === 'muted' && 'bg-muted/50', background === 'gradient' && 'bg-gradient-to-br from-sky-50 via-white to-emerald-50 dark:from-slate-900 dark:via-slate-950 dark:to-indigo-950', background === 'default' && '', className)}>
+        <section className={cn('rounded-2xl px-6 py-10 md:px-10', background === 'muted' && 'bg-muted/50', background === 'gradient' && 'bg-gradient-to-br from-sky-50 via-white to-emerald-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900', background === 'default' && '', className)}>
             {(title || description) && (
                 <div className="mb-8 text-center">
                     {Icon && (
-                        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-sky-500 to-emerald-600 text-white shadow-md">
-                            <Icon className="h-6 w-6" />
+                        <div className="mx-auto mb-4 w-fit">
+                            <IconBadge icon={Icon} variant="default" size="lg" />
                         </div>
                     )}
                     {title && <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">{title}</h2>}

--- a/docs/superpowers/plans/2026-03-22-visual-consistency-phase1.md
+++ b/docs/superpowers/plans/2026-03-22-visual-consistency-phase1.md
@@ -1,0 +1,835 @@
+# Visual Consistency Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify the site's visual language by consolidating color palettes, replacing inline gradient circles with a shared `IconBadge` component, standardizing card hover behavior, and fixing dark mode gradient tails and the lime-green nav badge.
+
+**Architecture:** All changes are visual-only (Tailwind class edits and one new shared component). `IconBadge` is created first since six other files depend on it. Remaining tasks are independent and can be done in any order after Task 1.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Tailwind CSS v3, Lucide React, Vitest + Testing Library
+
+**Spec:** `docs/superpowers/specs/2026-03-22-visual-consistency-phase1.md`
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `components/shared/icon-badge.tsx` | **Create** — new shared component |
+| `components/shared/icon-badge.test.tsx` | **Create** — unit tests |
+| `components/navigation/mobile-nav.tsx` | **Modify** — nav badge color |
+| `components/navigation/sidebar-nav.tsx` | **Modify** — nav badge color |
+| `components/shared/cta-banner.tsx` | **Modify** — dark gradient tail |
+| `components/shared/page-hero.tsx` | **Modify** — dark gradient tail |
+| `components/shared/section.tsx` | **Modify** — IconBadge + dark gradient tail |
+| `components/navigation/site-footer.tsx` | **Modify** — use IconBadge |
+| `components/blog/blog-card.tsx` | **Modify** — card hover behavior |
+| `components/product/product-teaser-card.tsx` | **Modify** — card hover behavior |
+| `components/shared/feature-grid.tsx` | **Modify** — card hover behavior + IconBadge |
+| `components/doc/doc-index-card.tsx` | **Modify** — card hover behavior + IconBadge |
+| `components/product/guitar-page.tsx` | **Modify** — IconBadge, borders, hover, color palette |
+| `components/product/ham-radio-kit-page.tsx` | **Modify** — IconBadge, borders, hover, color palette |
+
+---
+
+## Task 1: Create `IconBadge` component
+
+**Files:**
+- Create: `components/shared/icon-badge.tsx`
+- Create: `components/shared/icon-badge.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `components/shared/icon-badge.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { IconBadge } from './icon-badge';
+import { Radio } from 'lucide-react';
+
+describe('IconBadge', () => {
+    it('applies default sky→emerald gradient', () => {
+        const { container } = render(<IconBadge icon={Radio} />);
+        const div = container.firstChild as HTMLElement;
+        expect(div.className).toContain('from-sky-500');
+        expect(div.className).toContain('to-emerald-600');
+    });
+
+    it('applies guitar sky→indigo gradient', () => {
+        const { container } = render(<IconBadge icon={Radio} variant="guitar" />);
+        const div = container.firstChild as HTMLElement;
+        expect(div.className).toContain('from-sky-500');
+        expect(div.className).toContain('to-indigo-600');
+    });
+
+    it('applies sm size classes', () => {
+        const { container } = render(<IconBadge icon={Radio} size="sm" />);
+        const div = container.firstChild as HTMLElement;
+        expect(div.className).toContain('h-9');
+        expect(div.className).toContain('w-9');
+        expect(div.className).toContain('rounded-lg');
+    });
+
+    it('applies md size classes by default', () => {
+        const { container } = render(<IconBadge icon={Radio} />);
+        const div = container.firstChild as HTMLElement;
+        expect(div.className).toContain('h-10');
+        expect(div.className).toContain('w-10');
+        expect(div.className).toContain('rounded-lg');
+    });
+
+    it('applies lg size classes', () => {
+        const { container } = render(<IconBadge icon={Radio} size="lg" />);
+        const div = container.firstChild as HTMLElement;
+        expect(div.className).toContain('h-12');
+        expect(div.className).toContain('w-12');
+        expect(div.className).toContain('rounded-xl');
+    });
+
+    it('renders the icon', () => {
+        const { container } = render(<IconBadge icon={Radio} />);
+        expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run components/shared/icon-badge.test.tsx
+```
+
+Expected: FAIL — `Cannot find module './icon-badge'`
+
+- [ ] **Step 3: Create the component**
+
+Create `components/shared/icon-badge.tsx`:
+
+```tsx
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface IconBadgeProps {
+    icon: React.ElementType;
+    variant?: 'default' | 'guitar';
+    size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeClasses = {
+    sm: { wrapper: 'h-9 w-9 rounded-lg', icon: 'h-4 w-4' },
+    md: { wrapper: 'h-10 w-10 rounded-lg', icon: 'h-5 w-5' },
+    lg: { wrapper: 'h-12 w-12 rounded-xl', icon: 'h-6 w-6' },
+};
+
+const variantClasses = {
+    default: 'from-sky-500 to-emerald-600',
+    guitar: 'from-sky-500 to-indigo-600',
+};
+
+export function IconBadge({ icon: Icon, variant = 'default', size = 'md' }: IconBadgeProps) {
+    return (
+        <div className={cn('flex items-center justify-center bg-gradient-to-br shadow-sm text-white', sizeClasses[size].wrapper, variantClasses[variant])}>
+            <Icon className={sizeClasses[size].icon} />
+        </div>
+    );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run components/shared/icon-badge.test.tsx
+```
+
+Expected: 6/6 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/shared/icon-badge.tsx components/shared/icon-badge.test.tsx
+git commit -m "feat: add IconBadge shared component with default and guitar variants"
+```
+
+---
+
+## Task 2: Fix nav badges
+
+Replace the lime-green `#adfa1d` badge with sky-blue in both nav files.
+
+**Files:**
+- Modify: `components/navigation/mobile-nav.tsx:56`
+- Modify: `components/navigation/sidebar-nav.tsx:52`
+
+- [ ] **Step 1: Update `mobile-nav.tsx`**
+
+On line 56, replace:
+```
+bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000]
+```
+with:
+```
+bg-sky-500 px-1.5 py-0.5 text-xs leading-none text-white
+```
+
+- [ ] **Step 2: Update `sidebar-nav.tsx`**
+
+On line 52, replace:
+```
+bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000]
+```
+with:
+```
+bg-sky-500 px-1.5 py-0.5 text-xs leading-none text-white
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/navigation/mobile-nav.tsx components/navigation/sidebar-nav.tsx
+git commit -m "fix: replace lime-green nav badge with sky-500"
+```
+
+---
+
+## Task 3: Fix dark gradient tails in `cta-banner.tsx` and `page-hero.tsx`
+
+Remove the indigo tail from both shared layout gradient backgrounds.
+
+**Files:**
+- Modify: `components/shared/cta-banner.tsx:13`
+- Modify: `components/shared/page-hero.tsx:17`
+
+- [ ] **Step 1: Update `cta-banner.tsx`**
+
+On the `bg-gradient-to-br` class string, replace:
+```
+dark:from-slate-900 dark:via-slate-950 dark:to-indigo-900
+```
+with:
+```
+dark:from-slate-950 dark:via-slate-950 dark:to-slate-900
+```
+
+- [ ] **Step 2: Update `page-hero.tsx`**
+
+On the gradient div class string (line 17), replace:
+```
+dark:from-slate-900 dark:via-slate-950 dark:to-indigo-900
+```
+with:
+```
+dark:from-slate-950 dark:via-slate-950 dark:to-slate-900
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/shared/cta-banner.tsx components/shared/page-hero.tsx
+git commit -m "fix: remove indigo dark gradient tail from cta-banner and page-hero"
+```
+
+---
+
+## Task 4: Update `section.tsx` — IconBadge + dark gradient
+
+**Files:**
+- Modify: `components/shared/section.tsx`
+
+The current file:
+```tsx
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { LucideIcon } from 'lucide-react';
+```
+
+- [ ] **Step 1: Add IconBadge import and update the component**
+
+Replace the entire file content:
+
+```tsx
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { LucideIcon } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
+
+interface SectionProps {
+    background?: 'default' | 'gradient' | 'muted';
+    title?: string;
+    description?: string;
+    icon?: LucideIcon;
+    children: React.ReactNode;
+    className?: string;
+}
+
+export function Section({ background = 'default', title, description, icon: Icon, children, className }: SectionProps) {
+    return (
+        <section className={cn('rounded-2xl px-6 py-10 md:px-10', background === 'muted' && 'bg-muted/50', background === 'gradient' && 'bg-gradient-to-br from-sky-50 via-white to-emerald-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900', background === 'default' && '', className)}>
+            {(title || description) && (
+                <div className="mb-8 text-center">
+                    {Icon && (
+                        <div className="mx-auto mb-4 w-fit">
+                            <IconBadge icon={Icon} variant="default" size="lg" />
+                        </div>
+                    )}
+                    {title && <h2 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">{title}</h2>}
+                    {description && <p className="mt-2 text-muted-foreground">{description}</p>}
+                </div>
+            )}
+            {children}
+        </section>
+    );
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/shared/section.tsx
+git commit -m "refactor: use IconBadge in Section and fix dark gradient tail"
+```
+
+---
+
+## Task 5: Update `site-footer.tsx` — use IconBadge
+
+**Files:**
+- Modify: `components/navigation/site-footer.tsx:33-35`
+
+- [ ] **Step 1: Add import**
+
+Add to the existing imports at the top of `site-footer.tsx`:
+```tsx
+import { IconBadge } from '@/components/shared/icon-badge';
+```
+
+- [ ] **Step 2: Replace inline gradient div**
+
+Find and replace this block (lines 33-35):
+```tsx
+<div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-emerald-600 text-white shadow-sm">
+    <Radio className="h-5 w-5" />
+</div>
+```
+
+Replace with:
+```tsx
+<IconBadge icon={Radio} variant="default" size="sm" />
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/navigation/site-footer.tsx
+git commit -m "refactor: use IconBadge in site footer"
+```
+
+---
+
+## Task 6: Update `blog-card.tsx` — card hover behavior
+
+**Files:**
+- Modify: `components/blog/blog-card.tsx:19`
+
+- [ ] **Step 1: Update the article element class**
+
+On line 19, find:
+```
+transition-all group-hover:shadow-md group-hover:scale-[1.02]
+```
+
+Replace with:
+```
+transition-all group-hover:border-sky-500 group-hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]
+```
+
+The full resulting `<article>` opening tag should be:
+```tsx
+<article className="relative flex h-full flex-col overflow-hidden rounded-xl border border-border/60 bg-card p-5 shadow-sm transition-all group-hover:border-sky-500 group-hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]">
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/blog/blog-card.tsx
+git commit -m "refactor: replace scale hover with border accent on blog card"
+```
+
+---
+
+## Task 7: Update `product-teaser-card.tsx` — card hover behavior
+
+**Files:**
+- Modify: `components/product/product-teaser-card.tsx:20`
+
+- [ ] **Step 1: Update the Card className**
+
+On line 20, find:
+```tsx
+<Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
+```
+
+Replace with:
+```tsx
+<Card className="cursor-pointer hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150 h-full">
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/product/product-teaser-card.tsx
+git commit -m "refactor: replace shadow-lg hover with border accent on product teaser card"
+```
+
+---
+
+## Task 8: Update `feature-grid.tsx` — hover + IconBadge
+
+**Files:**
+- Modify: `components/shared/feature-grid.tsx`
+
+- [ ] **Step 1: Replace the full file content**
+
+```tsx
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { LucideIcon } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
+
+interface FeatureCardProps {
+    icon: LucideIcon;
+    title: string;
+    description: string;
+}
+
+export function FeatureCard({ icon: Icon, title, description }: FeatureCardProps) {
+    return (
+        <div className="group rounded-xl border border-border/60 bg-card p-6 shadow-sm transition-all hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]">
+            <div className="mb-4">
+                <IconBadge icon={Icon} variant="default" size="md" />
+            </div>
+            <h3 className="font-semibold text-foreground">{title}</h3>
+            <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+        </div>
+    );
+}
+
+interface FeatureGridProps {
+    columns?: 2 | 3 | 4;
+    children: React.ReactNode;
+    className?: string;
+}
+
+export function FeatureGrid({ columns = 3, children, className }: FeatureGridProps) {
+    return <div className={cn('grid gap-6', columns === 2 && 'grid-cols-1 md:grid-cols-2', columns === 3 && 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3', columns === 4 && 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4', className)}>{children}</div>;
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/shared/feature-grid.tsx
+git commit -m "refactor: use IconBadge and border accent hover in feature-grid"
+```
+
+---
+
+## Task 9: Update `doc-index-card.tsx` — hover + IconBadge
+
+**Files:**
+- Modify: `components/doc/doc-index-card.tsx`
+
+- [ ] **Step 1: Replace the full file content**
+
+```tsx
+import React from 'react';
+
+import Link from 'next/link';
+import { FileText, ExternalLink, LucideIcon } from 'lucide-react';
+import { IconBadge } from '@/components/shared/icon-badge';
+
+export enum DocIndexItemType {
+    Internal, // Displays a doc page icon
+    External, // Displays an external link icon
+}
+
+export interface DocIndexItem {
+    title: string;
+    href: string;
+    description: string;
+    type?: DocIndexItemType;
+}
+
+export interface DocIndexCardProps {
+    title: string;
+    description?: string;
+    items?: DocIndexItem[];
+    icon?: LucideIcon;
+}
+
+export function DocIndexCard(props: DocIndexCardProps) {
+    const Icon = props.icon;
+
+    return (
+        <div className="mb-6 mt-4">
+            <div className="mb-4 flex items-center gap-3">
+                {Icon && <IconBadge icon={Icon} variant="default" size="md" />}
+                <div>
+                    <h2 className="text-xl font-bold tracking-tight text-foreground">{props.title}</h2>
+                    {props.description && <p className="text-sm text-muted-foreground">{props.description}</p>}
+                </div>
+            </div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {props.items?.map((item, index) => {
+                    const ItemIcon = item.type === DocIndexItemType.External ? ExternalLink : FileText;
+                    const isExternal = item.type === DocIndexItemType.External;
+                    return (
+                        <Link key={index} href={item.href} target={isExternal ? '_blank' : undefined} className="group block">
+                            <div className="flex h-full items-start gap-4 rounded-xl border border-border/60 bg-card p-5 shadow-sm transition-all group-hover:border-sky-500 group-hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]">
+                                <div className="mt-0.5 flex-shrink-0 text-muted-foreground transition-colors group-hover:text-sky-600 dark:group-hover:text-sky-400">
+                                    <ItemIcon className="h-5 w-5" />
+                                </div>
+                                <div>
+                                    <h3 className="font-semibold text-foreground transition-colors group-hover:text-sky-600 dark:group-hover:text-sky-400">{item.title}</h3>
+                                    <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
+                                </div>
+                            </div>
+                        </Link>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/doc/doc-index-card.tsx
+git commit -m "refactor: use IconBadge and border accent hover in doc-index-card"
+```
+
+---
+
+## Task 10: Update `guitar-page.tsx`
+
+This is the most complex task. Read the full file before starting.
+
+**Files:**
+- Modify: `components/product/guitar-page.tsx`
+
+**Changes summary (from spec):**
+1. Add `IconBadge` import; replace inline icon div with `<IconBadge icon={...} variant="guitar" size="lg" />`
+2. All 6 `<Card>` instances: `border-2` → `border border-border`
+3. 4 interactive cards (lines 65, 75, 78, 81): `hover:shadow-lg transition-shadow` → `hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150`
+4. Decorative blobs: `bg-blue-400/20` → `bg-sky-400/20`, `bg-purple-400/20` → `bg-indigo-400/20`, `dark:bg-blue-500/10` → `dark:bg-sky-500/10`, `dark:bg-purple-500/10` → `dark:bg-indigo-500/10`
+5. Header overlay gradient: `from-blue-100/50 to-purple-100/50` → `from-sky-100/50 to-indigo-100/50`; dark variant: `dark:from-blue-900/10 dark:to-purple-900/10` → `dark:from-sky-900/10 dark:to-indigo-900/10`
+6. Related Content card (line 112) background gradient: `from-blue-50/50 to-purple-50/50 dark:from-blue-950/20 dark:to-purple-950/20` → `from-sky-50/50 to-indigo-50/50 dark:from-sky-950/20 dark:to-indigo-950/20`
+
+- [ ] **Step 1: Add import**
+
+Add to the imports at the top:
+```tsx
+import { IconBadge } from '@/components/shared/icon-badge';
+```
+
+- [ ] **Step 2: Replace the inline icon div**
+
+Find (around line 45):
+```tsx
+<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg">
+    <GuitarIcon className="h-6 w-6 text-white" />
+</div>
+```
+
+Replace with:
+```tsx
+<IconBadge icon={GuitarIcon} variant="guitar" size="lg" />
+```
+
+(Note: the exact icon component name may differ — use whatever icon is currently in use there.)
+
+- [ ] **Step 3: Fix decorative blob colors**
+
+Make these replacements globally in the file:
+- `bg-blue-400/20` → `bg-sky-400/20`
+- `bg-purple-400/20` → `bg-indigo-400/20`
+- `dark:bg-blue-500/10` → `dark:bg-sky-500/10`
+- `dark:bg-purple-500/10` → `dark:bg-indigo-500/10`
+
+- [ ] **Step 4: Fix overlay gradient**
+
+Replace:
+```
+from-blue-100/50 to-purple-100/50 dark:from-blue-900/10 dark:to-purple-900/10
+```
+with:
+```
+from-sky-100/50 to-indigo-100/50 dark:from-sky-900/10 dark:to-indigo-900/10
+```
+
+- [ ] **Step 5: Fix all 6 `border-2` → `border border-border`**
+
+Find all occurrences of `border-2 shadow-md` in this file and replace `border-2` with `border border-border`. There are 6 Card instances.
+
+- [ ] **Step 6: Update hover classes on 4 interactive cards**
+
+For lines 65, 75, 78, 81 (the cards with `hover:shadow-lg transition-shadow`), replace `hover:shadow-lg transition-shadow` with `hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150`.
+
+The Description card (line 88) and Related Content card (line 112) have no hover classes — do not add any.
+
+- [ ] **Step 7: Fix Related Content card background gradient**
+
+On line 112, replace:
+```
+from-blue-50/50 to-purple-50/50 dark:from-blue-950/20 dark:to-purple-950/20
+```
+with:
+```
+from-sky-50/50 to-indigo-50/50 dark:from-sky-950/20 dark:to-indigo-950/20
+```
+
+- [ ] **Step 8: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 9: Verify with grep (success criteria check)**
+
+```bash
+grep -n "from-blue\|from-purple\|to-purple\|border-2\|hover:scale" components/product/guitar-page.tsx
+```
+
+Expected: no output
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add components/product/guitar-page.tsx
+git commit -m "refactor: unify guitar-page color palette and card hover behavior"
+```
+
+---
+
+## Task 11: Update `ham-radio-kit-page.tsx`
+
+Read the full file before starting.
+
+**Files:**
+- Modify: `components/product/ham-radio-kit-page.tsx`
+
+**Changes summary (from spec):**
+1. Add `IconBadge` import; replace inline icon div (line 46, `from-amber-500 to-orange-600`) with `<IconBadge icon={...} variant="default" size="lg" />`
+2. All 5 `<Card>` instances at lines 62, 71, 107, 143, 167: `border-2` → `border border-border`
+3. 3 interactive cards (lines 62, 71, 107): `hover:shadow-lg transition-shadow` → `hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150`
+   - Note: lines 71 and 107 are inside `{isDummyLoad && ...}` blocks — changes still apply
+4. Decorative blobs: `bg-amber-400/20` → `bg-sky-400/20`, `bg-orange-400/20` → `bg-emerald-400/20`, `dark:bg-amber-500/10` → `dark:bg-sky-500/10`, `dark:bg-orange-500/10` → `dark:bg-emerald-500/10`
+5. Overlay gradient: `from-amber-100/50 via-transparent to-orange-100/50` → `from-sky-100/50 via-transparent to-emerald-100/50`; dark variant: `dark:from-amber-900/10 dark:via-transparent dark:to-orange-900/10` → `dark:from-sky-900/10 dark:via-transparent dark:to-emerald-900/10`
+6. Card background gradient on lines 71 and 167: `from-amber-50/50 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/20` → `from-sky-50/50 to-emerald-50/50 dark:from-sky-950/20 dark:to-emerald-950/20`
+
+- [ ] **Step 1: Add import**
+
+Add to imports:
+```tsx
+import { IconBadge } from '@/components/shared/icon-badge';
+```
+
+- [ ] **Step 2: Replace the inline icon div**
+
+Find (around line 46):
+```tsx
+<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-amber-500 to-orange-600 shadow-lg">
+    <Radio className="h-6 w-6 text-white" />
+</div>
+```
+
+Replace with:
+```tsx
+<IconBadge icon={Radio} variant="default" size="lg" />
+```
+
+(Use whatever icon is currently there — likely `Radio`.)
+
+- [ ] **Step 3: Fix decorative blob colors**
+
+Global replacements in file:
+- `bg-amber-400/20` → `bg-sky-400/20`
+- `bg-orange-400/20` → `bg-emerald-400/20`
+- `dark:bg-amber-500/10` → `dark:bg-sky-500/10`
+- `dark:bg-orange-500/10` → `dark:bg-emerald-500/10`
+
+- [ ] **Step 4: Fix overlay gradient**
+
+Replace:
+```
+from-amber-100/50 via-transparent to-orange-100/50 dark:from-amber-900/10 dark:via-transparent dark:to-orange-900/10
+```
+with:
+```
+from-sky-100/50 via-transparent to-emerald-100/50 dark:from-sky-900/10 dark:via-transparent dark:to-emerald-900/10
+```
+
+- [ ] **Step 5: Fix all 5 `border-2` → `border border-border`**
+
+Find all occurrences of `border-2` in this file and replace with `border border-border`. There are 5.
+
+- [ ] **Step 6: Update hover classes on 3 interactive cards**
+
+For lines 62, 71, 107 (cards with `hover:shadow-lg transition-shadow`), replace `hover:shadow-lg transition-shadow` with `hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150`.
+
+The non-interactive cards at lines 143 and 167 have no hover classes — do not add any.
+
+- [ ] **Step 7: Fix card background gradient on lines 71 and 167**
+
+Both cards have `from-amber-50/50 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/20`. Replace with:
+```
+from-sky-50/50 to-emerald-50/50 dark:from-sky-950/20 dark:to-emerald-950/20
+```
+
+- [ ] **Step 8: Run tests**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 9: Verify with grep (success criteria check)**
+
+```bash
+grep -n "from-amber\|from-orange\|to-orange\|border-2\|hover:scale" components/product/ham-radio-kit-page.tsx
+```
+
+Expected: no output
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add components/product/ham-radio-kit-page.tsx
+git commit -m "refactor: unify ham-radio-kit-page color palette and card hover behavior"
+```
+
+---
+
+## Final Verification
+
+After all tasks are complete, run these checks to verify success criteria:
+
+- [ ] **No banned colors in component files**
+
+```bash
+grep -r "from-blue-\|from-amber-\|from-purple-\|to-orange-\|to-purple-" components/ --include="*.tsx"
+```
+
+Expected: no output (only intentional sky/indigo guitar variants should exist)
+
+- [ ] **No scale hover on cards**
+
+```bash
+grep -r "hover:scale\|group-hover:scale" components/ --include="*.tsx"
+```
+
+Expected: no output
+
+- [ ] **No border-2 on product page inner cards**
+
+```bash
+grep -n "border-2" components/product/guitar-page.tsx components/product/ham-radio-kit-page.tsx
+```
+
+Expected: no output
+
+- [ ] **No lime-green badge**
+
+```bash
+grep -r "adfa1d" components/ --include="*.tsx"
+```
+
+Expected: no output
+
+- [ ] **No indigo tail in shared layout gradients**
+
+```bash
+grep -n "to-indigo-" components/shared/section.tsx components/shared/cta-banner.tsx components/shared/page-hero.tsx
+```
+
+Expected: no output
+
+- [ ] **All tests pass**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass

--- a/docs/superpowers/specs/2026-03-22-visual-consistency-phase1.md
+++ b/docs/superpowers/specs/2026-03-22-visual-consistency-phase1.md
@@ -1,0 +1,137 @@
+# Visual Consistency Phase 1 — Design Spec
+
+**Date:** 2026-03-22
+**Status:** Approved
+
+---
+
+## Overview
+
+Unify the visual language across the site: consolidate competing color palettes, create a shared icon badge component, standardize card borders and hover behavior, clean up dark mode depth inconsistency, and fix small legacy bugs. This is a visual-only refactor — no new features, no changes to page structure or routing.
+
+---
+
+## Goals
+
+1. **Color unification** — one primary gradient (sky→emerald), with sky→indigo as the single guitar-category variant. Remove amber→orange and blue→purple entirely.
+2. **IconBadge component** — replace all inline gradient-circle implementations with a single shared component.
+3. **Card consistency** — thin 1px border everywhere; sky-blue border accent on hover (no scale animation).
+4. **Dark mode depth** — standardize to two values site-wide: `slate-950` for page backgrounds, `slate-900` for card/panel surfaces.
+5. **Small fixes** — mobile nav lime green badge, dark gradient `to-indigo-*` tail removed.
+
+---
+
+## Design Decisions
+
+### Icon Badge Colors
+
+| Context | Gradient | Tailwind |
+|---------|----------|----------|
+| Default (all icons, footer, docs, kits) | sky→emerald | `from-sky-500 to-emerald-600` |
+| Guitar category only | sky→indigo | `from-sky-500 to-indigo-600` |
+
+Both variants share `sky-500` as the starting point — visually unified at first glance, subtly distinct on close inspection.
+
+### Card Hover Behavior
+
+All cards (blog, product teaser, doc index, feature grid) use:
+```
+hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]
+```
+Transition: `transition-all duration-150`
+
+Remove all `hover:scale-[1.02]` and `hover:scale-*` from cards. Remove `group-hover:scale-[1.02]`. The border accent is sufficient; scale feels decorative.
+
+### Card Border
+
+All cards standardize to `border border-border` (thin 1px, CSS variable). Remove `border-2` from `ham-radio-kit-page.tsx` and `guitar-page.tsx` inner cards.
+
+### Dark Mode Gradient Backgrounds
+
+Consolidate all section/hero/banner dark gradients to:
+```
+dark:from-slate-950 dark:via-slate-950 dark:to-slate-900
+```
+Replace all `dark:to-indigo-950` and `dark:to-indigo-900` occurrences in shared layout components. The indigo tail creates an unintended purple tint in dark mode.
+
+### Dark Mode Surface Colors
+
+- Page/section backgrounds: `dark:bg-slate-950`
+- Card/panel surfaces: `dark:bg-slate-900`
+- Elevated overlays (e.g., doc-image lightbox): `dark:bg-slate-800`
+
+No other slate values should appear as backgrounds.
+
+### Mobile Nav Badge
+
+Replace `bg-[#adfa1d] text-[#000000]` with `bg-sky-500 text-white`.
+
+---
+
+## New Component: `components/shared/icon-badge.tsx`
+
+```tsx
+interface IconBadgeProps {
+    icon: React.ElementType;
+    variant?: 'default' | 'guitar';
+    size?: 'sm' | 'md' | 'lg';
+}
+```
+
+| Prop | Value | Tailwind |
+|------|-------|----------|
+| `variant="default"` | sky→emerald | `from-sky-500 to-emerald-600` |
+| `variant="guitar"` | sky→indigo | `from-sky-500 to-indigo-600` |
+| `size="sm"` | 36×36px | `h-9 w-9 rounded-lg` — icon `h-4 w-4` |
+| `size="md"` | 40×40px | `h-10 w-10 rounded-lg` — icon `h-5 w-5` |
+| `size="lg"` | 48×48px | `h-12 w-12 rounded-xl` — icon `h-6 w-6` |
+
+Default: `variant="default"`, `size="md"`.
+
+Full classes on the wrapper div:
+```
+flex items-center justify-center bg-gradient-to-br shadow-sm text-white
++ size classes + rounded classes + gradient classes
+```
+
+No tests needed — it's a pure presentational component with no logic beyond prop-driven class selection.
+
+---
+
+## Files to Create or Modify
+
+| File | Change |
+|------|--------|
+| `components/shared/icon-badge.tsx` | Create — new shared component |
+| `components/product/guitar-page.tsx` | Use `IconBadge variant="guitar"`, fix inner card `border-2` → `border`, add hover accent |
+| `components/product/ham-radio-kit-page.tsx` | Use `IconBadge variant="default"`, fix inner card `border-2` → `border`, add hover accent |
+| `components/product/product-teaser-card.tsx` | Add hover accent, ensure `border border-border` |
+| `components/blog/blog-card.tsx` | Replace `group-hover:scale-[1.02]` with border accent hover |
+| `components/doc/doc-index-card.tsx` | Replace `group-hover:scale-[1.02]` with border accent hover, use `IconBadge` |
+| `components/shared/feature-grid.tsx` | Replace `hover:scale-[1.02]` with border accent hover, use `IconBadge` |
+| `components/shared/section.tsx` | Use `IconBadge`, fix dark gradient tail |
+| `components/shared/cta-banner.tsx` | Fix dark gradient tail |
+| `components/shared/page-hero.tsx` | Fix dark gradient tail |
+| `components/navigation/mobile-nav.tsx` | Replace `bg-[#adfa1d] text-[#000000]` with `bg-sky-500 text-white` |
+| `components/navigation/site-footer.tsx` | Use `IconBadge` |
+
+---
+
+## Out of Scope
+
+- Phase 2 layout changes (TOC, home page restructure, prev/next nav, container widths)
+- `DocAlert` colors (the per-level semantic colors are intentional and remain unchanged)
+- Shopify product purchase button styling
+- Any changes to page routing, content, or data
+
+---
+
+## Success Criteria
+
+- No `from-blue-500`, `from-amber-500`, `from-purple-*`, `to-orange-*`, `to-purple-*` in component files
+- No `hover:scale-*` or `group-hover:scale-*` on card components
+- No `border-2` on product page inner cards
+- No `#adfa1d` in codebase
+- No `to-indigo-*` in shared layout gradient backgrounds
+- `IconBadge` used in all 6 locations that previously had inline gradient circles
+- All tests pass

--- a/docs/superpowers/specs/2026-03-22-visual-consistency-phase1.md
+++ b/docs/superpowers/specs/2026-03-22-visual-consistency-phase1.md
@@ -60,11 +60,11 @@ Replace all `dark:to-indigo-950` and `dark:to-indigo-900` occurrences in shared 
 - Card/panel surfaces: `dark:bg-slate-900`
 - Elevated overlays (e.g., doc-image lightbox): `dark:bg-slate-800`
 
-No other slate values should appear as backgrounds.
+No other slate values should appear as backgrounds. This is a forward-looking standard; Phase 1 does not require auditing all existing files for compliance — only the files explicitly listed in the file table are in scope.
 
-### Mobile Nav Badge
+### Nav Badge (Mobile and Sidebar)
 
-Replace `bg-[#adfa1d] text-[#000000]` with `bg-sky-500 text-white`.
+Both `mobile-nav.tsx` and `sidebar-nav.tsx` contain the same lime-green badge. Replace `bg-[#adfa1d] text-[#000000]` with `bg-sky-500 text-white` in both files.
 
 ---
 
@@ -103,17 +103,18 @@ No tests needed — it's a pure presentational component with no logic beyond pr
 | File | Change |
 |------|--------|
 | `components/shared/icon-badge.tsx` | Create — new shared component |
-| `components/product/guitar-page.tsx` | Use `IconBadge variant="guitar"`, fix inner card `border-2` → `border`, add hover accent |
-| `components/product/ham-radio-kit-page.tsx` | Use `IconBadge variant="default"`, fix inner card `border-2` → `border`, add hover accent |
-| `components/product/product-teaser-card.tsx` | Add hover accent, ensure `border border-border` |
-| `components/blog/blog-card.tsx` | Replace `group-hover:scale-[1.02]` with border accent hover |
-| `components/doc/doc-index-card.tsx` | Replace `group-hover:scale-[1.02]` with border accent hover, use `IconBadge` |
-| `components/shared/feature-grid.tsx` | Replace `hover:scale-[1.02]` with border accent hover, use `IconBadge` |
-| `components/shared/section.tsx` | Use `IconBadge`, fix dark gradient tail |
-| `components/shared/cta-banner.tsx` | Fix dark gradient tail |
-| `components/shared/page-hero.tsx` | Fix dark gradient tail |
+| `components/product/guitar-page.tsx` | Use `<IconBadge icon={...} variant="guitar" size="lg" />` for the inline gradient icon div (existing gradient is `from-blue-500 to-purple-600` with `shadow-lg` — this changes structure, color, and shadow; `shadow-lg` → `shadow-sm` via `IconBadge` is intentional). Replace all `border-2` on `<Card>` elements with `border border-border` (applies to all 6 card instances at lines 65, 75, 78, 81, 88, 112). For the 4 interactive cards (lines 65, 75, 78, 81 — those with `hover:shadow-lg`), replace `hover:shadow-lg transition-shadow` with `hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150`. The 2 non-interactive cards get no hover classes: the Description card (line 88, `from-slate-50/50`) gets only `border-2` → `border border-border`; the Related Content card (line 112) gets `border-2` → `border border-border` AND the background gradient replacement `from-blue-50/50 to-purple-50/50 dark:from-blue-950/20 dark:to-purple-950/20` → `from-sky-50/50 to-indigo-50/50 dark:from-sky-950/20 dark:to-indigo-950/20`. Replace decorative blob colors: `bg-blue-400/20` → `bg-sky-400/20`, `bg-purple-400/20` → `bg-indigo-400/20`, `dark:bg-blue-500/10` → `dark:bg-sky-500/10`, `dark:bg-purple-500/10` → `dark:bg-indigo-500/10`. Replace header overlay gradient `from-blue-100/50 to-purple-100/50` with `from-sky-100/50 to-indigo-100/50` (dark variant: `dark:from-blue-900/10 dark:to-purple-900/10` → `dark:from-sky-900/10 dark:to-indigo-900/10`). |
+| `components/product/ham-radio-kit-page.tsx` | Use `<IconBadge icon={...} variant="default" size="lg" />` for the inline gradient icon div (existing gradient is `from-amber-500 to-orange-600` with `shadow-lg` — this changes structure, color, and shadow; `shadow-lg` → `shadow-sm` via `IconBadge` is intentional). Replace all `border-2` on `<Card>` elements with `border border-border` (applies to all 5 card instances at lines 62, 71, 107, 143, 167). For the 3 interactive cards (lines 62, 107 — plain; line 71 — amber-gradient), replace `hover:shadow-lg transition-shadow` with `hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150`. Note: lines 71 and 107 are inside `{isDummyLoad && ...}` conditional blocks — the hover changes still apply; they simply will not render for non-dummy-load products. The 2 non-interactive cards get no hover classes: the Specs card (line 143, `from-slate-50/50`) gets only `border-2` → `border border-border`; the card at line 167 gets `border-2` → `border border-border` AND the background gradient replacement `from-amber-50/50 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/20` → `from-sky-50/50 to-emerald-50/50 dark:from-sky-950/20 dark:to-emerald-950/20`. Replace decorative blob colors: `bg-amber-400/20` → `bg-sky-400/20`, `bg-orange-400/20` → `bg-emerald-400/20`, `dark:bg-amber-500/10` → `dark:bg-sky-500/10`, `dark:bg-orange-500/10` → `dark:bg-emerald-500/10`. Replace overlay gradient `from-amber-100/50 via-transparent to-orange-100/50` → `from-sky-100/50 via-transparent to-emerald-100/50`, dark variant `dark:from-amber-900/10 dark:via-transparent dark:to-orange-900/10` → `dark:from-sky-900/10 dark:via-transparent dark:to-emerald-900/10`. |
+| `components/product/product-teaser-card.tsx` | Uses Shadcn `<Card>` — add hover classes via `className` prop: replace `hover:shadow-lg transition-shadow` with `hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)] transition-all duration-150`. No restructuring needed. |
+| `components/blog/blog-card.tsx` | On the `<article>` element: remove `group-hover:shadow-md group-hover:scale-[1.02]`, add `group-hover:border-sky-500 group-hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]`. Keep existing `transition-all`. The resting border is `border-border/60` (60% opacity); the hover border `group-hover:border-sky-500` is intentionally solid (no opacity modifier) — this is consistent with the card hover standard. |
+| `components/doc/doc-index-card.tsx` | On the per-item row div: remove `group-hover:shadow-md group-hover:scale-[1.02]`, add `group-hover:border-sky-500 group-hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]`. Keep existing `transition-all`. Additionally, replace the section-level inline gradient div (`flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-emerald-600 text-white shadow-sm` at the top of the card) with `<IconBadge icon={...} variant="default" size="md" />`. Per-item icons inside the card use plain `text-muted-foreground` and are not changed. |
+| `components/shared/feature-grid.tsx` | On the `FeatureCard` wrapper div: remove `hover:shadow-md hover:scale-[1.02]`, add `hover:border-sky-500 hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]`. Keep existing `transition-all`. Replace the inline gradient div (`flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-emerald-600 text-white shadow-sm`) with `<IconBadge icon={Icon} variant="default" size="md" />`. |
+| `components/shared/section.tsx` | Replace the inline icon div (`h-12 w-12 rounded-xl from-sky-500 to-emerald-600`) with `<IconBadge icon={Icon} variant="default" size="lg" />`. Fix dark gradient: replace `dark:from-slate-900 dark:via-slate-950 dark:to-indigo-950` with `dark:from-slate-950 dark:via-slate-950 dark:to-slate-900`. Note: `section.tsx` types its `icon` prop as `LucideIcon`; `IconBadge` accepts `React.ElementType`, which is compatible — no prop type change needed on callers. |
+| `components/shared/cta-banner.tsx` | Fix dark gradient: replace `dark:from-slate-900 dark:via-slate-950 dark:to-indigo-900` with `dark:from-slate-950 dark:via-slate-950 dark:to-slate-900`. No other changes. |
+| `components/shared/page-hero.tsx` | Fix dark gradient: replace `dark:from-slate-900 dark:via-slate-950 dark:to-indigo-900` with `dark:from-slate-950 dark:via-slate-950 dark:to-slate-900`. No other changes. |
 | `components/navigation/mobile-nav.tsx` | Replace `bg-[#adfa1d] text-[#000000]` with `bg-sky-500 text-white` |
-| `components/navigation/site-footer.tsx` | Use `IconBadge` |
+| `components/navigation/sidebar-nav.tsx` | Replace `bg-[#adfa1d] text-[#000000]` with `bg-sky-500 text-white` (same badge pattern as mobile-nav) |
+| `components/navigation/site-footer.tsx` | Replace the 1 inline gradient div (`flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-sky-500 to-emerald-600 text-white shadow-sm`) with `<IconBadge icon={...} variant="default" size="sm" />`. The gradient colors are already sky→emerald — this is a structural consolidation, not a color change. No other changes needed in this file. |
 
 ---
 
@@ -128,10 +129,10 @@ No tests needed — it's a pure presentational component with no logic beyond pr
 
 ## Success Criteria
 
-- No `from-blue-500`, `from-amber-500`, `from-purple-*`, `to-orange-*`, `to-purple-*` in component files
+- No `from-blue-*`, `from-amber-*`, `from-purple-*`, `to-orange-*`, `to-purple-*` in component files
 - No `hover:scale-*` or `group-hover:scale-*` on card components
 - No `border-2` on product page inner cards
 - No `#adfa1d` in codebase
-- No `to-indigo-*` in shared layout gradient backgrounds
-- `IconBadge` used in all 6 locations that previously had inline gradient circles
+- No `to-indigo-*` in shared layout gradient backgrounds (`section.tsx`, `cta-banner.tsx`, `page-hero.tsx`)
+- `IconBadge` used in all 6 locations that previously had inline gradient circles: `guitar-page.tsx`, `ham-radio-kit-page.tsx`, `section.tsx`, `feature-grid.tsx`, `doc-index-card.tsx`, `site-footer.tsx`
 - All tests pass


### PR DESCRIPTION
## Summary

- Add shared `IconBadge` component (sky→emerald default, sky→indigo guitar variant) replacing all inline gradient icon divs in 6 locations
- Standardize card hover behavior site-wide: remove scale animations, replace with sky-blue border accent (`hover:border-sky-500` + custom shadow)
- Unify color palette: guitar pages → sky/indigo, ham radio pages → sky/emerald; remove amber/orange and blue/purple from component files
- Fix dark mode gradient tails in `section.tsx`, `cta-banner.tsx`, `page-hero.tsx` (remove `to-indigo-*`)
- Replace lime-green nav badge (`#adfa1d`) with `bg-sky-500` in mobile and sidebar nav

## Test Plan
- [x] All 32 unit tests passing
- [ ] Verify card hover behavior on blog, product, and doc index pages (light + dark mode)
- [ ] Verify `IconBadge` renders correctly in footer, section headers, feature grid, doc index, and product pages
- [ ] Verify no purple tint in dark mode gradients on section/hero/CTA components
- [ ] Verify nav badge is sky-blue on mobile and sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)