### PR TITLE
fix(test): update Body sub-item tests from Parts to Print/Bonding/Finishing

### DIFF
--- a/__tests__/config/relay-build-process.test.ts
+++ b/__tests__/config/relay-build-process.test.ts
@@ -45,12 +45,14 @@ describe('relayBuildProcess config', () => {
         expect(itemTitles).toEqual(['Lipstick', 'Reef', 'Velvet', 'Arc', 'Torch', 'Current', 'Hammer']);
     });
 
-    it('exposes Parts as a sub-item under the Body stage', () => {
+    it('exposes Print, Bonding, and Finishing as sub-items under the Body stage', () => {
         const body = relayBuildProcess.stages.find((s) => s.slug === 'body');
         expect(body).toBeDefined();
         const itemTitles = body!.items?.map((i) => i.title) ?? [];
-        expect(itemTitles).toEqual(['Parts']);
-        expect(body!.items?.[0].href).toBe('/relay/body/parts');
+        expect(itemTitles).toEqual(['Print', 'Bonding', 'Finishing']);
+        expect(body!.items?.[0].href).toBe('/relay/body/print');
+        expect(body!.items?.[1].href).toBe('/relay/body/bonding');
+        expect(body!.items?.[2].href).toBe('/relay/body/finishing');
     });
 
     it('every stage has a non-empty summary', () => {

--- a/components/navigation/relay-sidebar.test.tsx
+++ b/components/navigation/relay-sidebar.test.tsx
@@ -39,10 +39,14 @@ describe('RelayLayoutSidebar (platform mode)', () => {
         expect(assemblyLink.textContent).toMatch(/Planned/i);
     });
 
-    it('renders the Parts sub-link under the Body stage', () => {
+    it('renders Print, Bonding, and Finishing sub-links under the Body stage', () => {
         render(<RelayLayoutSidebar />);
-        const partsLink = screen.getByRole('link', { name: /^Parts$/ });
-        expect(partsLink).toHaveAttribute('href', '/relay/body/parts');
+        const printLink = screen.getByRole('link', { name: /^Print$/ });
+        const bondingLink = screen.getByRole('link', { name: /^Bonding$/ });
+        const finishingLink = screen.getByRole('link', { name: /^Finishing$/ });
+        expect(printLink).toHaveAttribute('href', '/relay/body/print');
+        expect(bondingLink).toHaveAttribute('href', '/relay/body/bonding');
+        expect(finishingLink).toHaveAttribute('href', '/relay/body/finishing');
     });
 
     it('lists the seven voicings in the sidebar', () => {


### PR DESCRIPTION
## Summary

- The `body-build-instructions` branch (PR #60) anticipated a single "Parts" sub-page under Body, but the actual implementation (PR #59) ships three pages: Print, Bonding, and Finishing
- Two tests were left asserting `['Parts']` at `/relay/body/parts`, causing the Netlify build to fail
- Updated both tests to match reality: assert Print/Bonding/Finishing sub-items with correct hrefs

## Test plan

- [ ] `__tests__/config/relay-build-process.test.ts` — `exposes Print, Bonding, and Finishing as sub-items` passes
- [ ] `components/navigation/relay-sidebar.test.tsx` — `renders Print, Bonding, and Finishing sub-links` passes
- [ ] All other tests remain green

🤖 Generated with [Claude Code](https://claude.ai/claude-code)