### PR TITLE
feat(discord): Level B integration — community callout with pinned messages

### DIFF
--- a/components/discord-community-callout.tsx
+++ b/components/discord-community-callout.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Link from 'next/link';
+import { siteConfig } from '@/config/site';
+import { fetchPinnedMessages } from '@/lib/discord';
+
+interface DiscordCommunityCalloutProps {
+    threadId?: string;
+    channelHref?: string;
+    message?: string;
+    className?: string;
+}
+
+export async function DiscordCommunityCallout({
+    threadId,
+    channelHref,
+    message = 'Ask questions and share your build with other builders.',
+    className,
+}: DiscordCommunityCalloutProps) {
+    const pins = threadId ? await fetchPinnedMessages(threadId) : [];
+    const serverHref = siteConfig.links.discord;
+    const discussHref = channelHref ?? serverHref;
+    const hasPins = pins.length > 0;
+    const showJoinLink = hasPins && discussHref !== serverHref;
+
+    return (
+        <div
+            className={`my-6 rounded-xl border border-indigo-500/20 bg-indigo-500/5 p-5 ${className ?? ''}`}
+        >
+            {hasPins ? (
+                <>
+                    <p className="font-semibold text-foreground">From the community</p>
+                    <ul className="mt-3 space-y-4">
+                        {pins.map((pin) => (
+                            <li key={pin.id} className="text-sm text-muted-foreground">
+                                <span className="font-medium text-foreground/80">
+                                    {pin.author.global_name ?? pin.author.username}:{' '}
+                                </span>
+                                {pin.content}
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            ) : (
+                <>
+                    <p className="font-semibold text-foreground">Join the community</p>
+                    <p className="mt-1 text-sm text-muted-foreground">{message}</p>
+                </>
+            )}
+
+            <div className="mt-4 flex flex-wrap gap-3">
+                <Link
+                    href={discussHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+                >
+                    {hasPins ? 'Ask a question →' : 'Open Discord →'}
+                </Link>
+                {showJoinLink && (
+                    <Link
+                        href={serverHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 rounded-lg border border-indigo-500/30 px-4 py-2 text-sm font-medium text-indigo-400 transition-colors hover:bg-indigo-500/10"
+                    >
+                        Join the server →
+                    </Link>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -39,6 +39,7 @@ import { RelayVoicingGrid, RelayVoicingCard } from '@/components/doc/relay-voici
 import { CardGrid, CardGridItem } from '@/components/doc/card-grid';
 import { RelayVoicingPickupChoices, RelayRecommendedPickups } from '@/components/relay/relay-recommended-pickups';
 import { RelayDiscordCta } from '@/components/relay/relay-discord-cta';
+import { DiscordCommunityCallout } from '@/components/discord-community-callout';
 import { RelayLabDisclosure } from '@/components/relay/relay-lab-disclosure';
 import { RelayWiringDiagram } from '@/components/relay/relay-wiring-diagram';
 import { RelayPickupMap } from '@/components/relay/relay-pickup-map';
@@ -180,6 +181,7 @@ const components: MDXComponents = {
     RelayVoicingCard,
     RelayRecommendedPickups,
     RelayDiscordCta,
+    DiscordCommunityCallout,
     RelayLabDisclosure,
     RelayWiringDiagram,
     RelayPickupMap,

--- a/content/relay/body/bonding.mdx
+++ b/content/relay/body/bonding.mdx
@@ -95,4 +95,4 @@ See [Finishing](/relay/body/finishing) for surface prep before hardware installa
 
 ## Community
 
-<RelayDiscordCta message="Ask questions of me and other builders if you have any printing challenges." />
+<DiscordCommunityCallout message="Ask questions about bonding — glue choices, clamping, alignment, and inspection." />

--- a/content/relay/body/bonding.mdx
+++ b/content/relay/body/bonding.mdx
@@ -95,4 +95,4 @@ See [Finishing](/relay/body/finishing) for surface prep before hardware installa
 
 ## Community
 
-<DiscordCommunityCallout message="Ask questions about bonding — glue choices, clamping, alignment, and inspection." />
+<DiscordCommunityCallout threadId="1506266150135271435" channelHref="https://discord.com/channels/1432214244459417693/1506266150135271435" message="Ask questions about bonding — glue choices, clamping, alignment, and inspection." />

--- a/content/relay/body/finishing.mdx
+++ b/content/relay/body/finishing.mdx
@@ -33,4 +33,4 @@ If you already know how to build and finish a guitar, you can safely venture off
 
 ## Community
 
-<DiscordCommunityCallout message="Ask questions about finishing — sanding, sealing, and what worked for other builders." />
+<DiscordCommunityCallout threadId="1506266425524752515" channelHref="https://discord.com/channels/1432214244459417693/1506266425524752515" message="Ask questions about finishing — sanding, sealing, and what worked for other builders." />

--- a/content/relay/body/finishing.mdx
+++ b/content/relay/body/finishing.mdx
@@ -33,4 +33,4 @@ If you already know how to build and finish a guitar, you can safely venture off
 
 ## Community
 
-<RelayDiscordCta message="Ask questions of me and other builders if you have any printing challenges." />
+<DiscordCommunityCallout message="Ask questions about finishing — sanding, sealing, and what worked for other builders." />

--- a/content/relay/body/index.mdx
+++ b/content/relay/body/index.mdx
@@ -36,4 +36,4 @@ I am providing you will affiliate links for Amazon.com for convenience and I may
 
 ## Community
 
-<RelayDiscordCta message="Ask questions of me and other builders before you get started and for help along the way." />
+<DiscordCommunityCallout message="Ask questions before you get started and for help along the way." />

--- a/content/relay/body/index.mdx
+++ b/content/relay/body/index.mdx
@@ -36,4 +36,4 @@ I am providing you will affiliate links for Amazon.com for convenience and I may
 
 ## Community
 
-<DiscordCommunityCallout message="Ask questions before you get started and for help along the way." />
+<DiscordCommunityCallout threadId="1506268185408831539" channelHref="https://discord.com/channels/1432214244459417693/1506268185408831539" message="Ask questions before you get started and for help along the way." />

--- a/content/relay/body/parts.mdx
+++ b/content/relay/body/parts.mdx
@@ -94,4 +94,4 @@ Skip this section if going with bare PET-CF / PET-GF as the final finish. Both m
     Replace this BomItem with the specific finish products I'd recommend, or expand to multiple BomItems if there's a primer/paint/clearcoat workflow. Substitution copy is intentionally permissive — verify it matches what I'd actually say.
 </DocAlert>
 
-<RelayDiscordCta message="Have a substitution that worked for you? Share it on Discord — I'll add verified alternates back into this list." />
+<DiscordCommunityCallout message="Have a substitution that worked for you? Share it — I'll add verified alternates back into this list." />

--- a/content/relay/body/parts.mdx
+++ b/content/relay/body/parts.mdx
@@ -94,4 +94,4 @@ Skip this section if going with bare PET-CF / PET-GF as the final finish. Both m
     Replace this BomItem with the specific finish products I'd recommend, or expand to multiple BomItems if there's a primer/paint/clearcoat workflow. Substitution copy is intentionally permissive — verify it matches what I'd actually say.
 </DocAlert>
 
-<DiscordCommunityCallout message="Have a substitution that worked for you? Share it — I'll add verified alternates back into this list." />
+<DiscordCommunityCallout threadId="1506267986506285106" channelHref="https://discord.com/channels/1432214244459417693/1506267986506285106" message="Have a substitution that worked for you? Share it — I'll add verified alternates back into this list." />

--- a/content/relay/body/print.mdx
+++ b/content/relay/body/print.mdx
@@ -112,4 +112,4 @@ Keep **Auto circle contour-hole compensation** enabled for the Cap as well. It i
 
 ## Community
 
-<RelayDiscordCta message="Ask questions of me and other builders if you have any printing challenges." />
+<DiscordCommunityCallout message="Ask questions about printing — challenges, settings, failures, and wins." />

--- a/content/relay/body/print.mdx
+++ b/content/relay/body/print.mdx
@@ -112,4 +112,4 @@ Keep **Auto circle contour-hole compensation** enabled for the Cap as well. It i
 
 ## Community
 
-<DiscordCommunityCallout message="Ask questions about printing — challenges, settings, failures, and wins." />
+<DiscordCommunityCallout threadId="1506265931654107297" channelHref="https://discord.com/channels/1432214244459417693/1506265931654107297" message="Ask questions about printing — challenges, settings, failures, and wins." />

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -17,7 +17,7 @@ export async function fetchPinnedMessages(threadId: string): Promise<DiscordPinn
             headers: {
                 Authorization: `Bot ${token}`,
             },
-            next: { revalidate: 3600 },
+            next: { revalidate: 300 },
         });
 
         if (!res.ok) return [];

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -1,0 +1,28 @@
+export interface DiscordPinnedMessage {
+    id: string;
+    content: string;
+    author: {
+        username: string;
+        global_name: string | null;
+    };
+    timestamp: string;
+}
+
+export async function fetchPinnedMessages(threadId: string): Promise<DiscordPinnedMessage[]> {
+    const token = process.env.DISCORD_BOT_TOKEN;
+    if (!token) return [];
+
+    try {
+        const res = await fetch(`https://discord.com/api/v10/channels/${threadId}/pins`, {
+            headers: {
+                Authorization: `Bot ${token}`,
+            },
+            next: { revalidate: 3600 },
+        });
+
+        if (!res.ok) return [];
+        return res.json();
+    } catch {
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `lib/discord.ts` — Discord REST API helper that fetches pinned messages from a Forum thread, with 5-minute ISR revalidation and graceful error handling (returns empty array on any failure)
- Adds `components/discord-community-callout.tsx` — async Server Component with two states: "From the community" (pinned messages + thread link + join server link) and a plain CTA fallback when no thread is configured or fetch fails
- Registers `DiscordCommunityCallout` in the MDX component registry
- Replaces `RelayDiscordCta` on all 5 body stage pages with `DiscordCommunityCallout`, each wired to its own Discord Forum thread

## Discord threads wired

| Page | Thread |
|------|--------|
| Body overview | `1506268185408831539` |
| Print | `1506265931654107297` |
| Bonding | `1506266150135271435` |
| Finishing | `1506266425524752515` |
| Parts | `1506267986506285106` |

## Test plan

- [ ] Verify fallback CTA renders on pages without a `threadId`
- [ ] Pin a message in one of the Discord threads and confirm it appears on the corresponding page within 5 minutes
- [ ] Confirm "Ask a question" button links to the correct thread
- [ ] Confirm "Join the server" button links to the Discord server invite
- [ ] Confirm pages without pinned messages show the "Join the community" CTA with correct message text

## Notes

Requires `DISCORD_BOT_TOKEN` in Netlify environment variables and **Message Content Intent** enabled in the Discord Developer Portal (Bot → Privileged Gateway Intents).

https://claude.ai/code/session_01B5yGdYerWRwdbLifEpzq8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5yGdYerWRwdbLifEpzq8D)_