### PR TITLE
fix(relay): apply PR#69 changes without breaking the build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Workflow Preferences
+
+- **Pull requests:** Never create PRs as drafts. The owner merges all PRs directly.
+
 ## Project Overview
 
 K7RHY Resonance Lab (https://k7rhy.app) — a Next.js content-driven site for ham radio electronics kits and musical instruments. Deployed on Netlify.

--- a/components/relay/relay-hero.test.tsx
+++ b/components/relay/relay-hero.test.tsx
@@ -15,21 +15,5 @@ describe('RelayHero', () => {
         expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
     });
 
-    it('renders the primary "Choose your voicing" CTA pointing to /relay/voicings', () => {
-        render(<RelayHero tagline="y" />);
-        const primary = screen.getByRole('link', { name: /choose your voicing/i });
-        expect(primary).toHaveAttribute('href', '/relay/voicings');
-    });
 
-    it('renders the secondary "Download body files" CTA linking to the body stage page', () => {
-        render(<RelayHero tagline="y" />);
-        const secondary = screen.getByRole('link', { name: /download body files/i });
-        expect(secondary).toHaveAttribute('href', '/relay/body');
-        expect(secondary).not.toHaveAttribute('target');
-    });
-
-    it('renders the micro-copy under the buttons', () => {
-        render(<RelayHero tagline="y" />);
-        expect(screen.getByText(/pick first, order parts/i)).toBeInTheDocument();
-    });
 });

--- a/components/relay/relay-hero.tsx
+++ b/components/relay/relay-hero.tsx
@@ -1,35 +1,13 @@
 import React from 'react';
-import Link from 'next/link';
-import { cn } from '@/lib/utils';
-import { relayBuildProcess } from '@/config/relay-build-process';
 
 interface RelayHeroProps {
     tagline: string;
 }
 
 export function RelayHero({ tagline }: RelayHeroProps) {
-    const bodyStage = relayBuildProcess.stages.find((s) => s.slug === 'body');
-    const bodyHref = bodyStage?.href ?? '/relay';
-    const bodyIsExternal = bodyStage?.isDiscord ?? false;
-
     return (
         <div className="my-8">
             <p className="max-w-2xl text-lg text-muted-foreground">{tagline}</p>
-
-            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-                <Link href="/relay/voicings" className={cn('inline-flex items-center justify-center rounded-lg bg-sky-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors', 'hover:bg-sky-700')}>
-                    Choose your voicing →
-                </Link>
-                <Link
-                    href={bodyHref}
-                    {...(bodyIsExternal ? { target: '_blank', rel: 'noopener noreferrer' as const } : {})}
-                    className={cn('inline-flex items-center justify-center rounded-lg border border-border bg-background px-5 py-2.5 text-sm font-semibold text-foreground transition-colors', 'hover:border-sky-500 hover:text-sky-600 dark:hover:text-sky-400')}
-                >
-                    ↓ Download body files
-                </Link>
-            </div>
-
-            <p className="mt-3 text-xs italic text-muted-foreground">Pick first, order parts, then start printing — they&rsquo;ll ship while the body prints.</p>
         </div>
     );
 }

--- a/content/relay/index.mdx
+++ b/content/relay/index.mdx
@@ -1,23 +1,13 @@
 ---
 title: 'Relay Guitar Platform'
-description: 'A 3D-printed electric guitar platform. One shared body, seven distinct instruments. Build the guitar that fits how you play.'
+description: 'A 3D-printed electric guitar platform. One shared body, many distinct instruments. Build the guitar that fits how you play.'
 ---
 
-<RelayHero tagline="A 3D-printed electric guitar platform. One shared body, seven distinct instruments. Build the guitar that fits how you play." />
+<RelayHero tagline="A 3D-printed electric guitar platform. One shared body, many distinct instruments. Build the guitar that fits how you play." />
 
-## What it is, what it costs, what you get
+The Relay Guitar Platform is something I built as a community project. I am providing you the information and resources that are necessary to print and build yourself a professional quality instrument that's suitable for players of all levels. I'm providing the models and documentation free of charge in the hopes of attracting a community of makers who want to support each other so that we can experiment, explore, and grow together.
 
-<CardGrid>
-    <CardGridItem title="What it is">
-        A 3D-printed electric guitar you build at home. One shared body, seven voicings — pick the sound first, then build the guitar around it.
-    </CardGridItem>
-    <CardGridItem title="What it costs">
-        $200–$400 in parts depending on the voicing, plus filament. Body prints on a conventional FDM printer; no specialty hardware required.
-    </CardGridItem>
-    <CardGridItem title="What you get">
-        A playable, giggable instrument you understand completely — because you built it. Same scale length and hardware as a Les Paul.
-    </CardGridItem>
-</CardGrid>
+I don't want to give you the impression that building a guitar is an easy, or even inexpensive, process. Parts of the process can be pretty challenging, but I've done my best to minimize those challenges and set you up for success. In terms of cost, if you're looking for a budget starter guitar, you can buy a decent instrument for less than it'll cost you to build one. However, from my perspective, there's nothing quite as satisfying as creating something with your own hands that plays and sounds amazing. When I started working on this platform I was able to source the materials for roughly $250. Now, 6-months later, it's closer to $400 if you buy everything new, but you can save a lot of money if you scavenge the parts from old or broken instruments. How you get the parts is entirely up to you.
 
 ## How a Relay build comes together
 
@@ -25,7 +15,7 @@ description: 'A 3D-printed electric guitar platform. One shared body, seven dist
 
 ## Voicings
 
-Seven voicings to choose from. Each is a different way to wire the same body — different pickup combinations, different selector logic, different sound.
+Many voicings to choose from. Each is a different way to wire the same body — different pickup combinations, different selector logic, different sound.
 
 <RelayVoicingGrid>
     <RelayVoicingCard slug="lipstick" name="Relay Lipstick" tagline="Humbuckers · Lipstick shaper" genres="Blues · Rock · Alternative · Indie" description="Bridge and neck humbuckers provide the main voices. The middle lipstick reshapes them with contour, texture, and air." href="/relay/voicings/lipstick" />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Applies the intended changes from PR #69 (iPad web UI edit): simplified `RelayHero` by removing the CTA buttons section, updated `content/relay/index.mdx` with new intro prose and "seven" → "many" wording
- Fixes the root cause of the Netlify build failure: the web UI edit used `{/* */}` to comment out the buttons block but left behind unused imports (`Link`, `cn`, `relayBuildProcess`) and variables (`bodyStage`, `bodyHref`, `bodyIsExternal`), which caused ESLint's `no-unused-vars` rule to fail during `next build`
- Removes the three stale tests in `relay-hero.test.tsx` that checked for the now-removed CTAs

## Test plan

- [ ] All 91 tests pass (`npx vitest run`)
- [ ] ESLint clean (`next lint`)
- [ ] Netlify deploy preview builds successfully
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtusddJhadUibEZHwrbgt6)_