### PR TITLE
Relay guitar electronics documentation templates and components

### DIFF
--- a/app/relay/[voicing]/[page]/page.tsx
+++ b/app/relay/[voicing]/[page]/page.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { notFound } from 'next/navigation';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import remarkGfm from 'remark-gfm';
+import components from '@/components/mdx-components';
+import { DocPage } from '@/components/doc/doc-page';
+import { RelayBreadcrumbBar } from '@/components/navigation/relay-sidebar';
+import { loadRelayPlatformSectionPage, buildRelayVoicingBreadcrumbs, type RelayPageFrontmatter } from '@/lib/relay';
+import { relayNav } from '@/config/relay-nav';
+
+type Props = { params: Promise<{ voicing: string; page: string }> };
+
+export function generateStaticParams() {
+    return Object.entries(relayNav).flatMap(([voicing, nav]) =>
+        nav.sections.flatMap((section) =>
+            (section.items ?? []).map((item) => ({ voicing, page: item.slug })),
+        ),
+    );
+}
+
+export async function generateMetadata({ params }: Props) {
+    const { voicing, page } = await params;
+    try {
+        const { frontmatter } = loadRelayPlatformSectionPage([voicing, page]);
+        return {
+            title: `${frontmatter.title} | Relay Guitar | K7RHY`,
+            description: frontmatter.description,
+            openGraph: { title: frontmatter.title, description: frontmatter.description },
+        };
+    } catch {
+        return {};
+    }
+}
+
+export default async function RelayVoicingSubPage({ params }: Props) {
+    const { voicing, page } = await params;
+    let content: string;
+    let frontmatter: RelayPageFrontmatter;
+    try {
+        ({ content, frontmatter } = loadRelayPlatformSectionPage([voicing, page]));
+    } catch {
+        notFound();
+    }
+    const breadcrumbs = buildRelayVoicingBreadcrumbs(voicing, [page], relayNav);
+    return (
+        <DocPage title={frontmatter!.title} breadcrumbs={<RelayBreadcrumbBar items={breadcrumbs} />}>
+            <MDXRemote source={content!} components={components} options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }} />
+        </DocPage>
+    );
+}

--- a/components/doc/component-labels.tsx
+++ b/components/doc/component-labels.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+const WIRE_COLORS: Record<string, string> = {
+    red: '#ef4444',
+    black: '#1f2937',
+    white: '#e5e7eb',
+    green: '#22c55e',
+    yellow: '#fbbf24',
+    blue: '#3b82f6',
+    bare: '#d4b483',
+    silver: '#9ca3af',
+    orange: '#f97316',
+    shield: '#9ca3af',
+};
+
+function resolveWireColor(wire: string): string {
+    return WIRE_COLORS[wire.toLowerCase()] ?? wire;
+}
+
+interface ComponentLabelsProps {
+    children: React.ReactNode;
+}
+
+interface ComponentLabelProps {
+    id: string;
+    component: string;
+    wire?: string;
+    description: string;
+}
+
+export function ComponentLabels({ children }: ComponentLabelsProps) {
+    return (
+        <div className="my-4 overflow-hidden rounded-lg border text-sm">
+            <table className="w-full">
+                <thead>
+                    <tr className="border-b bg-muted/40">
+                        <th className="py-2 pl-4 pr-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Label</th>
+                        <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Component</th>
+                        <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Wire</th>
+                        <th className="py-2 pl-3 pr-4 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Description</th>
+                    </tr>
+                </thead>
+                <tbody>{children}</tbody>
+            </table>
+        </div>
+    );
+}
+
+export function ComponentLabel({ id, component, wire, description }: ComponentLabelProps) {
+    const color = wire ? resolveWireColor(wire) : null;
+    const isDark = wire?.toLowerCase() === 'black';
+
+    return (
+        <tr className="border-b last:border-0 hover:bg-muted/20">
+            <td className="py-2 pl-4 pr-3 font-mono text-xs font-bold text-indigo-600 dark:text-indigo-400">{id}</td>
+            <td className="px-3 py-2 text-muted-foreground">{component}</td>
+            <td className="px-3 py-2">
+                {color && (
+                    <span className="flex items-center gap-1.5">
+                        <span
+                            className="inline-block h-3 w-3 shrink-0 rounded-full ring-1 ring-black/10 dark:ring-white/10"
+                            style={{ backgroundColor: color }}
+                            aria-hidden="true"
+                        />
+                        <span className={isDark ? 'text-xs capitalize dark:text-muted-foreground' : 'text-xs capitalize text-muted-foreground'}>{wire}</span>
+                    </span>
+                )}
+            </td>
+            <td className="py-2 pl-3 pr-4 text-muted-foreground">{description}</td>
+        </tr>
+    );
+}

--- a/components/doc/control-positions.tsx
+++ b/components/doc/control-positions.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface ControlPositionsProps {
+    switchLabel?: string;
+    children: React.ReactNode;
+}
+
+interface ControlPositionProps {
+    label: string;
+    name: string;
+    children?: React.ReactNode;
+}
+
+export function ControlPositions({ switchLabel, children }: ControlPositionsProps) {
+    return (
+        <div className="my-4">
+            {switchLabel && (
+                <p className="mb-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">{switchLabel}</p>
+            )}
+            <div className="divide-y overflow-hidden rounded-lg border">{children}</div>
+        </div>
+    );
+}
+
+export function ControlPosition({ label, name, children }: ControlPositionProps) {
+    return (
+        <div className="flex gap-3 px-4 py-3">
+            <div className="shrink-0 pt-0.5">
+                <span
+                    className={cn(
+                        'inline-flex min-w-[26px] items-center justify-center rounded-full px-1.5 py-0.5',
+                        'bg-indigo-100 text-xs font-semibold tabular-nums text-indigo-700',
+                        'dark:bg-indigo-900/60 dark:text-indigo-300',
+                    )}
+                >
+                    {label}
+                </span>
+            </div>
+            <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold">{name}</p>
+                {children && <div className="mt-0.5 text-sm text-muted-foreground">{children}</div>}
+            </div>
+        </div>
+    );
+}

--- a/components/doc/wiring-connections.tsx
+++ b/components/doc/wiring-connections.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+interface WiringConnectionsProps {
+    children: React.ReactNode;
+}
+
+interface WireConnectionProps {
+    from: string;
+    to: string;
+    notes?: string;
+}
+
+export function WiringConnections({ children }: WiringConnectionsProps) {
+    return (
+        <div className="my-4 overflow-hidden rounded-lg border text-sm">
+            <table className="w-full">
+                <thead>
+                    <tr className="border-b bg-muted/40">
+                        <th className="py-2 pl-4 pr-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">From</th>
+                        <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">To</th>
+                        <th className="py-2 pl-3 pr-4 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</th>
+                    </tr>
+                </thead>
+                <tbody>{children}</tbody>
+            </table>
+        </div>
+    );
+}
+
+export function WireConnection({ from, to, notes }: WireConnectionProps) {
+    return (
+        <tr className="border-b last:border-0 hover:bg-muted/20">
+            <td className="py-2.5 pl-4 pr-3">
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs font-semibold text-indigo-600 dark:text-indigo-400">{from}</code>
+            </td>
+            <td className="px-3 py-2.5">
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs font-semibold text-indigo-600 dark:text-indigo-400">{to}</code>
+            </td>
+            <td className="py-2.5 pl-3 pr-4 text-muted-foreground">{notes ?? ''}</td>
+        </tr>
+    );
+}

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -49,6 +49,9 @@ import { RelayHero } from '@/components/relay/relay-hero';
 import { RelayProcessOverview } from '@/components/relay/relay-process-overview';
 import { RelayDownloadCallout } from '@/components/relay/relay-download-callout';
 import { DocTerm } from '@/components/doc/doc-term';
+import { ControlPositions, ControlPosition } from '@/components/doc/control-positions';
+import { ComponentLabels, ComponentLabel } from '@/components/doc/component-labels';
+import { WiringConnections, WireConnection } from '@/components/doc/wiring-connections';
 
 //import { Style } from "@/registry/styles"
 
@@ -192,6 +195,12 @@ const components: MDXComponents = {
     RelayHero,
     RelayProcessOverview,
     RelayDownloadCallout,
+    ControlPositions,
+    ControlPosition,
+    ComponentLabels,
+    ComponentLabel,
+    WiringConnections,
+    WireConnection,
 };
 
 // interface MdxProps {

--- a/components/navigation/relay-sidebar.tsx
+++ b/components/navigation/relay-sidebar.tsx
@@ -107,6 +107,35 @@ function VoicingSidebar({ voicing }: { voicing: string }) {
                 </div>
             </div>
 
+            {voicingNav.sections.length > 0 && (
+                <div className="border-t pt-4">
+                    {voicingNav.sections.map((section) => (
+                        <div key={section.title} className="mb-3">
+                            <h4 className="mb-1 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{section.title}</h4>
+                            <ul className="grid grid-flow-row auto-rows-max text-sm">
+                                {section.items?.map((item) => {
+                                    const href = `/relay/${voicing}/${item.slug}`;
+                                    const isActive = pathname === href;
+                                    return (
+                                        <li key={item.slug}>
+                                            <Link
+                                                href={href}
+                                                className={cn(
+                                                    'flex w-full items-center rounded-md border border-transparent px-2 py-1 hover:underline',
+                                                    isActive ? 'font-medium text-foreground' : 'text-muted-foreground',
+                                                )}
+                                            >
+                                                {item.title}
+                                            </Link>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </div>
+                    ))}
+                </div>
+            )}
+
             <div className="border-t pt-4">
                 <h4 className="mb-1 rounded-md px-2 py-1 text-sm font-semibold">All voicings</h4>
                 <RelayVoicingLineupNav />
@@ -123,6 +152,11 @@ export function RelayLayoutSidebar() {
     const relayIndex = segments.indexOf('relay');
     const nextSegment = relayIndex >= 0 ? (segments[relayIndex + 1] ?? '') : '';
     const voicingSlug = nextSegment === 'voicings' ? (segments[relayIndex + 2] ?? '') : '';
+
+    // Also show the voicing sidebar for direct voicing sub-pages like /relay/lipstick/bom.
+    if (!voicingSlug && nextSegment in relayNav) {
+        return <VoicingSidebar voicing={nextSegment} />;
+    }
 
     // Voicing-level sidebar only on /relay/voicings/<slug> (a specific voicing — not the gallery).
     // Everything else (including /relay/voicings, /relay/body, /relay/assembly) uses the platform sidebar.

--- a/config/relay-nav.ts
+++ b/config/relay-nav.ts
@@ -9,7 +9,15 @@ export const relayNav: RelayNav = {
     lipstick: {
         title: 'Relay Lipstick',
         status: 'ready',
-        sections: [],
+        sections: [
+            {
+                title: 'Electronics',
+                items: [
+                    { title: 'Parts List', slug: 'bom' },
+                    { title: 'Wiring Guide', slug: 'wiring' },
+                ],
+            },
+        ],
     },
     reef: {
         title: 'Relay Reef',
@@ -19,7 +27,15 @@ export const relayNav: RelayNav = {
     velvet: {
         title: 'Relay Velvet',
         status: 'ready',
-        sections: [],
+        sections: [
+            {
+                title: 'Electronics',
+                items: [
+                    { title: 'Parts List', slug: 'bom' },
+                    { title: 'Wiring Guide', slug: 'wiring' },
+                ],
+            },
+        ],
     },
     arc: {
         title: 'Relay Arc',
@@ -29,7 +45,15 @@ export const relayNav: RelayNav = {
     torch: {
         title: 'Relay Torch',
         status: 'ready',
-        sections: [],
+        sections: [
+            {
+                title: 'Electronics',
+                items: [
+                    { title: 'Parts List', slug: 'bom' },
+                    { title: 'Wiring Guide', slug: 'wiring' },
+                ],
+            },
+        ],
     },
     current: {
         title: 'Relay Current',

--- a/content/relay/lipstick/wiring.mdx
+++ b/content/relay/lipstick/wiring.mdx
@@ -104,6 +104,15 @@ Test on the bench before the components go into the body.
     <ProcStep text="Check toggle switch continuity">
         Set your multimeter to continuity mode. Move the toggle to each of the three positions and verify continuity from SW-C to the expected lug (SW-B in position 1, both in position 2, SW-N in position 3). No continuity should exist between SW-B and SW-N directly.
     </ProcStep>
+    <ProcStep text="Resistance test — verify signal paths">
+        Set your multimeter to resistance (Ω) mode. With volume at maximum, probe between J-TIP and J-SLV. Expected readings by toggle position:
+
+        - **Position 1** (Bridge only): ~11.2 kΩ
+        - **Position 2** (Bridge + Neck, parallel): ~4.5 kΩ
+        - **Position 3** (Neck only): ~7.6 kΩ
+
+        With the lipstick blend engaged (push-push), each reading drops — a parallel pickup path is added. Position 3 + blend should read ~3.4 kΩ (neck 7.6K ∥ lipstick 6.0K). Position 1 + blend will be lower than 11.2K but the exact value depends on the partial split configuration. Open (OL) means a broken connection in that path. A reading much higher than expected in position 2 (e.g. 18–19 kΩ) suggests the two pickups may be wired in series instead of parallel. Individual pickups can vary ±10% from the spec values above.
+    </ProcStep>
     <ProcStep text="Check for ground shorts on the signal path">
         Probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short.
     </ProcStep>

--- a/content/relay/lipstick/wiring.mdx
+++ b/content/relay/lipstick/wiring.mdx
@@ -1,0 +1,116 @@
+---
+title: 'Wiring Guide'
+description: 'Step-by-step wiring instructions for the Relay Lipstick.'
+---
+
+The Lipstick circuit has two layers. The 3-way toggle selects between the bridge humbucker, both humbuckers together, and the neck humbucker. The push-push volume adds the lipstick shaper on top of whichever humbucker position is selected, and simultaneously engages a partial coil split on the bridge with level compensation to keep the blend balanced.
+
+<DocAlert level="important" title="Shield the cavity before installing components">
+    The lipstick pickup is sensitive to interference. Apply copper foil tape to all cavity walls and the floor first — doing it after assembly is much harder and the shielding is not optional.
+</DocAlert>
+
+## Component Labels
+
+Each connection point in this guide has a short label. Use the table below as a reference while wiring — the same labels appear on the component diagram.
+
+<DocImage
+    title="Relay Lipstick Wiring Diagram"
+    src="/images/relay/lipstick/wiring-diagram.png"
+    alt="Labeled wiring diagram showing all connection points for the Relay Lipstick"
+    triggerImageSize={300}
+    popupImageSize={1200}
+/>
+
+<ComponentLabels>
+    <ComponentLabel id="NP-H" component="Neck Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="NP-G" component="Neck Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="NP-W" component="Neck Pickup" wire="white" description="Coil tap wire (for partial split)" />
+    <ComponentLabel id="BP-H" component="Bridge Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="BP-G" component="Bridge Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="BP-W" component="Bridge Pickup" wire="white" description="Coil tap wire (for partial split)" />
+    <ComponentLabel id="LP-H" component="Lipstick Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="LP-G" component="Lipstick Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="SW-B" component="3-Way Toggle" description="Bridge lug — receives bridge pickup hot" />
+    <ComponentLabel id="SW-N" component="3-Way Toggle" description="Neck lug — receives neck pickup hot" />
+    <ComponentLabel id="SW-C" component="3-Way Toggle" description="Common lug — output to volume pot" />
+    <ComponentLabel id="VOL-IN" component="Volume Pot (push-push)" description="Input lug — signal in from selector" />
+    <ComponentLabel id="VOL-W" component="Volume Pot (push-push)" description="Wiper lug — signal out to jack" />
+    <ComponentLabel id="VOL-B" component="Volume Pot (push-push)" description="Back of pot — connect to ground bus" />
+    <ComponentLabel id="VOL-PP" component="Volume Pot (push-push)" description="Push-push switch contacts — engages lipstick blend" />
+    <ComponentLabel id="TON-IN" component="Tone Pot (push-pull)" description="Input lug — tapped from VOL-IN" />
+    <ComponentLabel id="TON-W" component="Tone Pot (push-pull)" description="Wiper lug — to tone capacitor" />
+    <ComponentLabel id="TON-B" component="Tone Pot (push-pull)" description="Back of pot — connect to ground bus" />
+    <ComponentLabel id="TON-PP" component="Tone Pot (push-pull)" description="Push-pull switch contacts — engages alternate contour" />
+    <ComponentLabel id="CAP-H" component="Tone Capacitor" description="Hot leg — connects to TON-W" />
+    <ComponentLabel id="CAP-G" component="Tone Capacitor" description="Ground leg — connects to ground bus" />
+    <ComponentLabel id="J-TIP" component="Output Jack" description="Tip lug (hot signal to amp)" />
+    <ComponentLabel id="J-SLV" component="Output Jack" description="Sleeve lug (ground)" />
+    <ComponentLabel id="GND" component="Ground Bus" description="Common ground — cavity foil, pot backs, pickup grounds, jack sleeve" />
+</ComponentLabels>
+
+## Connections
+
+<WiringConnections>
+    <WireConnection from="NP-H" to="SW-N" notes="Neck pickup hot to neck lug of toggle" />
+    <WireConnection from="BP-H" to="SW-B" notes="Bridge pickup hot to bridge lug of toggle" />
+    <WireConnection from="SW-C" to="VOL-IN" notes="Toggle output to volume input" />
+    <WireConnection from="VOL-IN" to="TON-IN" notes="Tap from volume input to tone input" />
+    <WireConnection from="VOL-W" to="J-TIP" notes="Volume wiper to jack tip" />
+    <WireConnection from="TON-W" to="CAP-H" notes="Tone wiper to capacitor" />
+    <WireConnection from="LP-H" to="VOL-PP" notes="Lipstick hot to push-push switch — see diagram for exact contact" />
+    <WireConnection from="BP-W" to="VOL-PP" notes="Bridge coil tap to push-push switch — partial split on engagement" />
+    <WireConnection from="TON-PP" to="[TODO]" notes="Push-pull alternate contour — wiring TBD from final circuit diagram" />
+    <WireConnection from="NP-G" to="GND" notes="" />
+    <WireConnection from="BP-G" to="GND" notes="" />
+    <WireConnection from="LP-G" to="GND" notes="" />
+    <WireConnection from="NP-W" to="GND" notes="Coil tap grounded when lipstick blend is off" />
+    <WireConnection from="VOL-B" to="GND" notes="" />
+    <WireConnection from="TON-B" to="GND" notes="" />
+    <WireConnection from="CAP-G" to="GND" notes="" />
+    <WireConnection from="J-SLV" to="GND" notes="" />
+</WiringConnections>
+
+## Wiring Procedure
+
+<Proc title="Wiring Steps">
+    <ProcStep text="Shield the cavity">
+        Apply copper foil tape to all cavity walls and the floor. Overlap foil sections by at least 2mm for continuity. Solder a short jumper wire across any gap between sections that don't overlap. Connect the foil to the ground bus with a short wire soldered to the foil surface.
+    </ProcStep>
+    <ProcStep text="Pre-tin all solder points">
+        Apply a small dot of solder to every lug and pad before making any connections. Pre-tinning uses less heat on the components and gives cleaner joints.
+    </ProcStep>
+    <ProcStep text="Wire the 3-way toggle">
+        Connect NP-H to SW-N and BP-H to SW-B. Run a wire from SW-C to VOL-IN. This is the main humbucker selector circuit.
+    </ProcStep>
+    <ProcStep text="Wire the volume and tone pots">
+        Connect VOL-IN to TON-IN (tap, not a through connection). Connect VOL-W to J-TIP. Connect TON-W to CAP-H and CAP-G to GND.
+    </ProcStep>
+    <ProcStep text="Wire the lipstick blend circuit">
+        [TODO: document the exact push-push switch wiring for the lipstick blend, including the coil tap connections on the bridge pickup and any level compensation components.]
+    </ProcStep>
+    <ProcStep text="Wire the push-pull tone contour">
+        [TODO: document the exact push-pull switch wiring for the alternate voicing contour.]
+    </ProcStep>
+    <ProcStep text="Connect the ground bus">
+        Connect NP-G, BP-G, LP-G, NP-W (when blend off), VOL-B, TON-B, CAP-G, and J-SLV all to GND. Ensure the cavity foil connects to this same ground point.
+    </ProcStep>
+</Proc>
+
+## Pre-Installation Test
+
+Test on the bench before the components go into the body.
+
+<Proc title="Bench Test">
+    <ProcStep text="Check toggle switch continuity">
+        Set your multimeter to continuity mode. Move the toggle to each of the three positions and verify continuity from SW-C to the expected lug (SW-B in position 1, both in position 2, SW-N in position 3). No continuity should exist between SW-B and SW-N directly.
+    </ProcStep>
+    <ProcStep text="Check for ground shorts on the signal path">
+        Probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short.
+    </ProcStep>
+    <ProcStep text="Test the push-push volume function">
+        With the blend engaged (push-push activated), verify that LP-H has a path to J-TIP. With it disengaged, verify that path is broken.
+    </ProcStep>
+    <ProcStep text="Tap test each pickup">
+        Plug a cable into J-TIP and into an amp at low volume. Tap each pickup's pole pieces with a metal screwdriver. Verify all three pickups are audible in the appropriate positions — humbuckers via the toggle, lipstick via the push-push blend.
+    </ProcStep>
+</Proc>

--- a/content/relay/torch/bom.mdx
+++ b/content/relay/torch/bom.mdx
@@ -1,0 +1,65 @@
+---
+title: 'Supply List'
+description: 'Everything you need to build a Relay Torch, with sourcing links and current prices.'
+---
+
+Read this before you buy anything. Items marked **Specific** mean that exact part — don't swap it out. Items marked **Flexible** have a real alternative listed below them.
+
+<DecisionNote variant="info" title="These are the parts I actually use.">
+    I've linked to exactly what I build with. When something is marked Flexible, I'll tell you what the tradeoff is so you can decide. When it's marked Specific, I've already learned that lesson the hard way.
+</DecisionNote>
+
+## Hardware
+
+<BomSection>
+    <BomItem title="Guitar Neck" href="https://amzn.to/41ko1a1" source="Amazon" itemKey="guitar-neck" fallback="$60.00">
+        I've bought several necks with identical listed specs and had meaningful variation in how they fit the pocket. Some required light sanding before seating correctly. Budget time for fitting and read [What Will Fit](/relay/lipstick/compatibility) before you order.
+    </BomItem>
+    <BomItem title="Fixed Hardtail Bridge" href="https://amzn.to/4smY8ST" source="Amazon" itemKey="hardtail-bridge" fallback="$15.00" />
+    <BomItem title="Neck Mounting Ferrules" href="https://amzn.to/4rOYP6x" source="Amazon" itemKey="neck-ferrules" fallback="$10.00">
+        These press into the back of the body and receive the neck bolts. Install them after you've confirmed neck alignment — they're permanent.
+    </BomItem>
+    <BomItem title="String Ferrule Plate" href="https://amzn.to/4d2Rblc" source="Amazon" itemKey="string-ferrule-plate" fallback="$10.00" substitution="Individual string ferrules work here. They're cheaper and easier to source, but you'll press each one separately and need to keep them aligned during installation. The plate is simpler and looks cleaner." />
+    <BomItem title="Locking Tuners" href="https://amzn.to/40HSQW2" source="Amazon" itemKey="locking-tuners" fallback="$35.00" substitution="Standard non-locking tuners work fine. Slightly slower restringing and marginally less tuning stability while strings settle. Save the money if budget is tight." />
+    <BomItem title="Strap Buttons" href="https://amzn.to/4uH46j0" source="Amazon" itemKey="strap-buttons" fallback="$11.00" substitution="Any standard strap button fits. Use your existing strap locks if preferred." />
+    <BomItem title="Guitar Strings (9–42), 3-pack" href="https://amzn.to/4bZbI9a" source="Amazon" itemKey="guitar-strings" fallback="$20.00" substitution="Any 9–42 light gauge strings work. Stick with 9s until the instrument is dialed in.">
+        Three packs because you'll break at least one string during setup.
+    </BomItem>
+    <BomItem title="Knobs" href="https://amzn.to/3PAKPzI" source="Amazon" itemKey="knobs" fallback="$10.00" substitution="Any knob that fits a split-shaft pot. Check shaft diameter before buying." />
+</BomSection>
+
+## Pickups
+
+The Mean 90 in the middle is the point of Torch — it needs to be aggressive enough to push the mids forward. The bridge humbucker should be hot but not muddy; avoid anything over about 14kΩ DC resistance or the Mean 90 starts to feel soft by comparison.
+
+<BomSection>
+    <BomItem title="Neck Humbucker — GFS Professional Series Alnico II" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="torch-neck-pickup" fallback="$37.00" specific>
+        Moderate-output Alnico II. Keeps the neck position warm without competing with the Mean 90's mid-forward character.
+    </BomItem>
+    <BomItem title="Middle P90-type — GFS Mean 90" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="torch-middle-pickup" fallback="$40.00" specific>
+        The voice this model is built around. The Mean 90's strong midrange is not optional — substituting a scooped or warm-voiced pickup removes the reason to build Torch in the first place.
+    </BomItem>
+    <BomItem title="Bridge Humbucker — GFS VEH Alnico V" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="torch-bridge-pickup" fallback="$37.00" specific>
+        Hotter than the neck but still in the moderate range. The Alnico V magnet gives it clarity and punch without being sharp or thin.
+    </BomItem>
+</BomSection>
+
+## Electronics
+
+<BomSection>
+    <BomItem title="Volume Pot (500k)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="torch-volume-pot" fallback="$8.00">
+        Standard 500k audio taper pot for volume. No special function required.
+    </BomItem>
+    <BomItem title="Tone Pot (500k push-pull)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="torch-tone-pot" fallback="$12.00" specific>
+        The push-pull engages the edge contour. A standard pot works as a tone control but loses the contour function.
+    </BomItem>
+    <BomItem title="Selector Switch (5-way blade)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="torch-selector-switch" fallback="$10.00" specific>
+        Must be a 5-way blade — do not use a 3-way. Position 3 (middle) and positions 2 and 4 (combined) are active destinations in this model.
+    </BomItem>
+    <BomItem title="Tone Capacitor" href="https://amzn.to/3NEJ18n" source="Amazon" itemKey="tone-capacitor" fallback="$10.00" substitution="Cap value is tonal preference. Caps are cheap — experiment freely." />
+    <BomItem title="Output Jack" href="https://amzn.to/4bGpEUv" source="Amazon" itemKey="output-jack" fallback="$5.00" substitution='Any standard 1/4" mono output jack works. Measure the cavity opening if substituting.' />
+    <BomItem title="Hookup Wire" href="https://amzn.to/4bDGenX" source="Amazon" itemKey="hookup-wire" fallback="$7.00" substitution="Any 22–24 AWG stranded hookup wire. Avoid solid core — it fatigues with vibration." />
+    <BomItem title="Copper Foil Tape" href="https://amzn.to/4smieg1" source="Amazon" itemKey="copper-foil-tape" fallback="$9.00" specific>
+        Used to shield the control cavity. Must be conductive adhesive type.
+    </BomItem>
+</BomSection>

--- a/content/relay/torch/wiring.mdx
+++ b/content/relay/torch/wiring.mdx
@@ -1,0 +1,109 @@
+---
+title: 'Wiring Guide'
+description: 'Step-by-step wiring instructions for the Relay Torch.'
+---
+
+Torch uses a standard 5-way HSH wiring scheme. The 5-way blade gives the Mean 90 its own position (3) and two combined positions (2 and 4) that blend its midrange character with the adjacent humbuckers. The volume is a standard pot. The push-pull tone engages the edge contour.
+
+<DocAlert level="important" title="Shield the cavity before installing components">
+    Apply copper foil tape to all cavity walls and the floor before installing anything. Do this before components go in — it's difficult to do properly once the pots and switch are mounted.
+</DocAlert>
+
+## Component Labels
+
+Each connection point in this guide has a short label. Use the table below as a reference — the same labels appear on the component diagram.
+
+<DocImage
+    title="Relay Torch Wiring Diagram"
+    src="/images/relay/torch/wiring-diagram.png"
+    alt="Labeled wiring diagram showing all connection points for the Relay Torch"
+    triggerImageSize={300}
+    popupImageSize={1200}
+/>
+
+<ComponentLabels>
+    <ComponentLabel id="NP-H" component="Neck Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="NP-G" component="Neck Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="MP-H" component="Middle Pickup (Mean 90)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="MP-G" component="Middle Pickup (Mean 90)" wire="black" description="Ground wire" />
+    <ComponentLabel id="BP-H" component="Bridge Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="BP-G" component="Bridge Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="SW-BP" component="5-Way Selector" description="Bridge pickup input lug — see diagram for physical lug number" />
+    <ComponentLabel id="SW-MP" component="5-Way Selector" description="Middle pickup input lug — see diagram for physical lug number" />
+    <ComponentLabel id="SW-NP" component="5-Way Selector" description="Neck pickup input lug — see diagram for physical lug number" />
+    <ComponentLabel id="SW-OUT" component="5-Way Selector" description="Output lug (common) — signal to volume pot" />
+    <ComponentLabel id="VOL-IN" component="Volume Pot (500k)" description="Input lug — signal in from selector" />
+    <ComponentLabel id="VOL-W" component="Volume Pot (500k)" description="Wiper lug — signal out to jack" />
+    <ComponentLabel id="VOL-B" component="Volume Pot (500k)" description="Back of pot — connect to ground bus" />
+    <ComponentLabel id="TON-IN" component="Tone Pot (push-pull)" description="Input lug — tapped from VOL-IN" />
+    <ComponentLabel id="TON-W" component="Tone Pot (push-pull)" description="Wiper lug — to tone capacitor" />
+    <ComponentLabel id="TON-B" component="Tone Pot (push-pull)" description="Back of pot — connect to ground bus" />
+    <ComponentLabel id="TON-PP" component="Tone Pot (push-pull)" description="Push-pull switch contacts — engages edge contour" />
+    <ComponentLabel id="CAP-H" component="Tone Capacitor" description="Hot leg — connects to TON-W" />
+    <ComponentLabel id="CAP-G" component="Tone Capacitor" description="Ground leg — connects to ground bus" />
+    <ComponentLabel id="J-TIP" component="Output Jack" description="Tip lug (hot signal to amp)" />
+    <ComponentLabel id="J-SLV" component="Output Jack" description="Sleeve lug (ground)" />
+    <ComponentLabel id="GND" component="Ground Bus" description="Common ground — cavity foil, pot backs, pickup grounds, jack sleeve" />
+</ComponentLabels>
+
+## Connections
+
+<WiringConnections>
+    <WireConnection from="BP-H" to="SW-BP" notes="Bridge pickup hot to switch bridge lug" />
+    <WireConnection from="MP-H" to="SW-MP" notes="Middle pickup hot to switch middle lug" />
+    <WireConnection from="NP-H" to="SW-NP" notes="Neck pickup hot to switch neck lug" />
+    <WireConnection from="SW-OUT" to="VOL-IN" notes="Switch output to volume input" />
+    <WireConnection from="VOL-IN" to="TON-IN" notes="Tap from volume input to tone input" />
+    <WireConnection from="VOL-W" to="J-TIP" notes="Volume wiper to jack tip" />
+    <WireConnection from="TON-W" to="CAP-H" notes="Tone wiper to capacitor" />
+    <WireConnection from="TON-PP" to="[TODO]" notes="Push-pull edge contour — wiring TBD from final circuit diagram" />
+    <WireConnection from="BP-G" to="GND" notes="" />
+    <WireConnection from="MP-G" to="GND" notes="" />
+    <WireConnection from="NP-G" to="GND" notes="" />
+    <WireConnection from="VOL-B" to="GND" notes="" />
+    <WireConnection from="TON-B" to="GND" notes="" />
+    <WireConnection from="CAP-G" to="GND" notes="" />
+    <WireConnection from="J-SLV" to="GND" notes="" />
+</WiringConnections>
+
+## Wiring Procedure
+
+<Proc title="Wiring Steps">
+    <ProcStep text="Shield the cavity">
+        Apply copper foil tape to all cavity walls and the floor. Overlap foil sections by at least 2mm for continuity. Solder a short jumper wire across any gap between sections that don't overlap. Connect the foil to the ground bus with a short wire.
+    </ProcStep>
+    <ProcStep text="Pre-tin all solder points">
+        Apply a small dot of solder to every lug and pad before making any connections. Pre-tinning uses less heat on the components and gives cleaner joints.
+    </ProcStep>
+    <ProcStep text="Wire the 5-way selector">
+        Connect BP-H to SW-BP, MP-H to SW-MP, and NP-H to SW-NP. The exact physical lug numbers depend on the switch brand — refer to the component diagram. Run a wire from SW-OUT to VOL-IN.
+    </ProcStep>
+    <ProcStep text="Wire the volume and tone pots">
+        Tap a wire from VOL-IN to TON-IN. Connect VOL-W to J-TIP. Connect TON-W to CAP-H and CAP-G to GND.
+    </ProcStep>
+    <ProcStep text="Wire the push-pull edge contour">
+        [TODO: document the exact push-pull switch wiring for the Torch edge contour.]
+    </ProcStep>
+    <ProcStep text="Connect the ground bus">
+        Connect BP-G, MP-G, NP-G, VOL-B, TON-B, CAP-G, and J-SLV all to GND. Ensure the cavity foil connects to this same point.
+    </ProcStep>
+</Proc>
+
+## Pre-Installation Test
+
+Test on the bench before the components go into the body.
+
+<Proc title="Bench Test">
+    <ProcStep text="Check selector switch continuity">
+        Set your multimeter to continuity mode. Move the selector to each of the five positions and verify continuity from SW-OUT to the expected input lug. Position 3 (center) should connect to SW-MP only. Positions 2 and 4 should show continuity to SW-MP and one adjacent lug.
+    </ProcStep>
+    <ProcStep text="Check for ground shorts on the signal path">
+        Probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short.
+    </ProcStep>
+    <ProcStep text="Tap test each pickup">
+        Plug a cable into J-TIP and into an amp at low volume. Tap each pickup's pole pieces with a metal screwdriver. Move the selector through all five positions and verify the correct pickup responds — Mean 90 in position 3, bridge in position 1, neck in position 5.
+    </ProcStep>
+    <ProcStep text="Test the push-pull edge contour">
+        Pull the tone knob up and verify the contour engages. The change in character should be audible when tapping pickup poles. Push it back down and verify it returns to standard tone response.
+    </ProcStep>
+</Proc>

--- a/content/relay/torch/wiring.mdx
+++ b/content/relay/torch/wiring.mdx
@@ -97,6 +97,17 @@ Test on the bench before the components go into the body.
     <ProcStep text="Check selector switch continuity">
         Set your multimeter to continuity mode. Move the selector to each of the five positions and verify continuity from SW-OUT to the expected input lug. Position 3 (center) should connect to SW-MP only. Positions 2 and 4 should show continuity to SW-MP and one adjacent lug.
     </ProcStep>
+    <ProcStep text="Resistance test — verify signal paths">
+        Set your multimeter to resistance (Ω) mode. With volume at maximum, probe between J-TIP and J-SLV. Expected readings by selector position:
+
+        - **Position 1** (Bridge only): ~11.2 kΩ
+        - **Position 2** (Bridge + Middle, parallel): ~4.9 kΩ
+        - **Position 3** (Middle only): ~8.7 kΩ
+        - **Position 4** (Neck + Middle, parallel): ~4.1 kΩ
+        - **Position 5** (Neck only): ~7.6 kΩ
+
+        Open (OL) means a broken connection in that path. A reading much higher than expected in position 2 or 4 (e.g. 20 kΩ) suggests the two pickups may be wired in series instead of parallel. Individual pickups can vary ±10% from the spec values above.
+    </ProcStep>
     <ProcStep text="Check for ground shorts on the signal path">
         Probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short.
     </ProcStep>

--- a/content/relay/velvet/bom.mdx
+++ b/content/relay/velvet/bom.mdx
@@ -1,0 +1,65 @@
+---
+title: 'Supply List'
+description: 'Everything you need to build a Relay Velvet, with sourcing links and current prices.'
+---
+
+Read this before you buy anything. Items marked **Specific** mean that exact part — don't swap it out. Items marked **Flexible** have a real alternative listed below them.
+
+<DecisionNote variant="info" title="These are the parts I actually use.">
+    I've linked to exactly what I build with. When something is marked Flexible, I'll tell you what the tradeoff is so you can decide. When it's marked Specific, I've already learned that lesson the hard way.
+</DecisionNote>
+
+## Hardware
+
+<BomSection>
+    <BomItem title="Guitar Neck" href="https://amzn.to/41ko1a1" source="Amazon" itemKey="guitar-neck" fallback="$60.00">
+        I've bought several necks with identical listed specs and had meaningful variation in how they fit the pocket. Some required light sanding before seating correctly. Budget time for fitting and read [What Will Fit](/relay/lipstick/compatibility) before you order.
+    </BomItem>
+    <BomItem title="Fixed Hardtail Bridge" href="https://amzn.to/4smY8ST" source="Amazon" itemKey="hardtail-bridge" fallback="$15.00" />
+    <BomItem title="Neck Mounting Ferrules" href="https://amzn.to/4rOYP6x" source="Amazon" itemKey="neck-ferrules" fallback="$10.00">
+        These press into the back of the body and receive the neck bolts. Install them after you've confirmed neck alignment — they're permanent.
+    </BomItem>
+    <BomItem title="String Ferrule Plate" href="https://amzn.to/4d2Rblc" source="Amazon" itemKey="string-ferrule-plate" fallback="$10.00" substitution="Individual string ferrules work here. They're cheaper and easier to source, but you'll press each one separately and need to keep them aligned during installation. The plate is simpler and looks cleaner." />
+    <BomItem title="Locking Tuners" href="https://amzn.to/40HSQW2" source="Amazon" itemKey="locking-tuners" fallback="$35.00" substitution="Standard non-locking tuners work fine. Slightly slower restringing and marginally less tuning stability while strings settle. Save the money if budget is tight." />
+    <BomItem title="Strap Buttons" href="https://amzn.to/4uH46j0" source="Amazon" itemKey="strap-buttons" fallback="$11.00" substitution="Any standard strap button fits. Use your existing strap locks if preferred." />
+    <BomItem title="Guitar Strings (9–42), 3-pack" href="https://amzn.to/4bZbI9a" source="Amazon" itemKey="guitar-strings" fallback="$20.00" substitution="Any 9–42 light gauge strings work. Stick with 9s until the instrument is dialed in.">
+        Three packs because you'll break at least one string during setup.
+    </BomItem>
+    <BomItem title="Knobs" href="https://amzn.to/3PAKPzI" source="Amazon" itemKey="knobs" fallback="$10.00" substitution="Any knob that fits a split-shaft pot. Check shaft diameter before buying." />
+</BomSection>
+
+## Pickups
+
+Both humbuckers are Alnico II — soft attack, moderate output. That combination keeps the sound warm without getting stiff or bright. The Retrotron Nashville needs to be clear but not aggressive; avoid hot or dark substitutions.
+
+<BomSection>
+    <BomItem title="Neck Humbucker — GFS Professional Series Alnico II" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="velvet-neck-pickup" fallback="$37.00" specific>
+        Warm and clear in the neck position. Pairs with the Retrotron without overpowering it in the combined positions.
+    </BomItem>
+    <BomItem title="Middle Filtertron — GFS Retrotron Nashville" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="velvet-middle-pickup" fallback="$45.00" specific>
+        The defining character of this model. The Retrotron's balanced, articulate sound is what makes position 3 the main Velvet destination. Substituting a different pickup type will change the voicing significantly.
+    </BomItem>
+    <BomItem title="Bridge Humbucker — GFS Professional Series Alnico II" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="velvet-bridge-pickup" fallback="$37.00" specific>
+        Same pickup as the neck. Keeps output balanced across positions so the middle doesn't feel weak by comparison.
+    </BomItem>
+</BomSection>
+
+## Electronics
+
+<BomSection>
+    <BomItem title="Volume Pot (500k)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="velvet-volume-pot" fallback="$8.00">
+        Standard 500k audio taper pot for volume. No special function required here.
+    </BomItem>
+    <BomItem title="Tone Pot (500k push-pull)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="velvet-tone-pot" fallback="$12.00" specific>
+        The push-pull engages the Velvet focus contour. A standard pot will work as a tone control but loses the contour function.
+    </BomItem>
+    <BomItem title="Selector Switch (5-way blade)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="velvet-selector-switch" fallback="$10.00" specific>
+        Must be a 5-way blade. Verify the listing before ordering — do not use a 3-way here. Position 3 (middle) is a main destination in this model.
+    </BomItem>
+    <BomItem title="Tone Capacitor" href="https://amzn.to/3NEJ18n" source="Amazon" itemKey="tone-capacitor" fallback="$10.00" substitution="Cap value is tonal preference. Listed value gives a warm but not muddy roll-off. Caps are cheap — experiment freely." />
+    <BomItem title="Output Jack" href="https://amzn.to/4bGpEUv" source="Amazon" itemKey="output-jack" fallback="$5.00" substitution='Any standard 1/4" mono output jack works. Measure the cavity opening if substituting.' />
+    <BomItem title="Hookup Wire" href="https://amzn.to/4bDGenX" source="Amazon" itemKey="hookup-wire" fallback="$7.00" substitution="Any 22–24 AWG stranded hookup wire. Avoid solid core — it fatigues with vibration." />
+    <BomItem title="Copper Foil Tape" href="https://amzn.to/4smieg1" source="Amazon" itemKey="copper-foil-tape" fallback="$9.00" specific>
+        Used to shield the control cavity. Must be conductive adhesive type.
+    </BomItem>
+</BomSection>

--- a/content/relay/velvet/wiring.mdx
+++ b/content/relay/velvet/wiring.mdx
@@ -1,0 +1,109 @@
+---
+title: 'Wiring Guide'
+description: 'Step-by-step wiring instructions for the Relay Velvet.'
+---
+
+Velvet uses a standard 5-way HSH (humbucker-filtertron-humbucker) wiring scheme. The 5-way blade gives the Retrotron Nashville its own position (3) and two combined positions (2 and 4). The volume is a standard pot. The push-pull tone engages the Velvet focus contour.
+
+<DocAlert level="important" title="Shield the cavity before installing components">
+    Apply copper foil tape to all cavity walls and the floor before installing anything. The Retrotron Nashville is more sensitive to interference than a standard humbucker.
+</DocAlert>
+
+## Component Labels
+
+Each connection point in this guide has a short label. Use the table below as a reference — the same labels appear on the component diagram.
+
+<DocImage
+    title="Relay Velvet Wiring Diagram"
+    src="/images/relay/velvet/wiring-diagram.png"
+    alt="Labeled wiring diagram showing all connection points for the Relay Velvet"
+    triggerImageSize={300}
+    popupImageSize={1200}
+/>
+
+<ComponentLabels>
+    <ComponentLabel id="NP-H" component="Neck Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="NP-G" component="Neck Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="MP-H" component="Middle Pickup (Retrotron)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="MP-G" component="Middle Pickup (Retrotron)" wire="black" description="Ground wire" />
+    <ComponentLabel id="BP-H" component="Bridge Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="BP-G" component="Bridge Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="SW-BP" component="5-Way Selector" description="Bridge pickup input lug — see diagram for physical lug number" />
+    <ComponentLabel id="SW-MP" component="5-Way Selector" description="Middle pickup input lug — see diagram for physical lug number" />
+    <ComponentLabel id="SW-NP" component="5-Way Selector" description="Neck pickup input lug — see diagram for physical lug number" />
+    <ComponentLabel id="SW-OUT" component="5-Way Selector" description="Output lug (common) — signal to volume pot" />
+    <ComponentLabel id="VOL-IN" component="Volume Pot (500k)" description="Input lug — signal in from selector" />
+    <ComponentLabel id="VOL-W" component="Volume Pot (500k)" description="Wiper lug — signal out to jack" />
+    <ComponentLabel id="VOL-B" component="Volume Pot (500k)" description="Back of pot — connect to ground bus" />
+    <ComponentLabel id="TON-IN" component="Tone Pot (push-pull)" description="Input lug — tapped from VOL-IN" />
+    <ComponentLabel id="TON-W" component="Tone Pot (push-pull)" description="Wiper lug — to tone capacitor" />
+    <ComponentLabel id="TON-B" component="Tone Pot (push-pull)" description="Back of pot — connect to ground bus" />
+    <ComponentLabel id="TON-PP" component="Tone Pot (push-pull)" description="Push-pull switch contacts — engages focus contour" />
+    <ComponentLabel id="CAP-H" component="Tone Capacitor" description="Hot leg — connects to TON-W" />
+    <ComponentLabel id="CAP-G" component="Tone Capacitor" description="Ground leg — connects to ground bus" />
+    <ComponentLabel id="J-TIP" component="Output Jack" description="Tip lug (hot signal to amp)" />
+    <ComponentLabel id="J-SLV" component="Output Jack" description="Sleeve lug (ground)" />
+    <ComponentLabel id="GND" component="Ground Bus" description="Common ground — cavity foil, pot backs, pickup grounds, jack sleeve" />
+</ComponentLabels>
+
+## Connections
+
+<WiringConnections>
+    <WireConnection from="BP-H" to="SW-BP" notes="Bridge pickup hot to switch bridge lug" />
+    <WireConnection from="MP-H" to="SW-MP" notes="Middle pickup hot to switch middle lug" />
+    <WireConnection from="NP-H" to="SW-NP" notes="Neck pickup hot to switch neck lug" />
+    <WireConnection from="SW-OUT" to="VOL-IN" notes="Switch output to volume input" />
+    <WireConnection from="VOL-IN" to="TON-IN" notes="Tap from volume input to tone input" />
+    <WireConnection from="VOL-W" to="J-TIP" notes="Volume wiper to jack tip" />
+    <WireConnection from="TON-W" to="CAP-H" notes="Tone wiper to capacitor" />
+    <WireConnection from="TON-PP" to="[TODO]" notes="Push-pull focus contour — wiring TBD from final circuit diagram" />
+    <WireConnection from="BP-G" to="GND" notes="" />
+    <WireConnection from="MP-G" to="GND" notes="" />
+    <WireConnection from="NP-G" to="GND" notes="" />
+    <WireConnection from="VOL-B" to="GND" notes="" />
+    <WireConnection from="TON-B" to="GND" notes="" />
+    <WireConnection from="CAP-G" to="GND" notes="" />
+    <WireConnection from="J-SLV" to="GND" notes="" />
+</WiringConnections>
+
+## Wiring Procedure
+
+<Proc title="Wiring Steps">
+    <ProcStep text="Shield the cavity">
+        Apply copper foil tape to all cavity walls and the floor. Overlap foil sections by at least 2mm for continuity. Solder a short jumper wire across any gap between sections that don't overlap. Connect the foil to the ground bus with a short wire.
+    </ProcStep>
+    <ProcStep text="Pre-tin all solder points">
+        Apply a small dot of solder to every lug and pad before making any connections. Pre-tinning uses less heat on the components and gives cleaner joints.
+    </ProcStep>
+    <ProcStep text="Wire the 5-way selector">
+        Connect BP-H to SW-BP, MP-H to SW-MP, and NP-H to SW-NP. The exact physical lug numbers depend on the switch brand — refer to the component diagram. Run a wire from SW-OUT to VOL-IN.
+    </ProcStep>
+    <ProcStep text="Wire the volume and tone pots">
+        Tap a wire from VOL-IN to TON-IN. Connect VOL-W to J-TIP. Connect TON-W to CAP-H and CAP-G to GND.
+    </ProcStep>
+    <ProcStep text="Wire the push-pull focus contour">
+        [TODO: document the exact push-pull switch wiring for the Velvet focus contour.]
+    </ProcStep>
+    <ProcStep text="Connect the ground bus">
+        Connect BP-G, MP-G, NP-G, VOL-B, TON-B, CAP-G, and J-SLV all to GND. Ensure the cavity foil connects to this same point.
+    </ProcStep>
+</Proc>
+
+## Pre-Installation Test
+
+Test on the bench before the components go into the body.
+
+<Proc title="Bench Test">
+    <ProcStep text="Check selector switch continuity">
+        Set your multimeter to continuity mode. Move the selector to each of the five positions and verify continuity from SW-OUT to the expected input lug. Position 3 (center) should connect to SW-MP only. Positions 2 and 4 should show continuity to SW-MP and to one adjacent lug.
+    </ProcStep>
+    <ProcStep text="Check for ground shorts on the signal path">
+        Probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short.
+    </ProcStep>
+    <ProcStep text="Tap test each pickup">
+        Plug a cable into J-TIP and into an amp at low volume. Tap each pickup's pole pieces with a metal screwdriver. Move the selector through all five positions and verify the correct pickup responds in each position — Retrotron Nashville in position 3, bridge in position 1, neck in position 5.
+    </ProcStep>
+    <ProcStep text="Test the push-pull tone contour">
+        Pull the tone knob up and verify the contour engages. The character change should be audible when tapping pickup poles. Push it back down and verify it returns to the standard tone response.
+    </ProcStep>
+</Proc>

--- a/content/relay/velvet/wiring.mdx
+++ b/content/relay/velvet/wiring.mdx
@@ -97,6 +97,17 @@ Test on the bench before the components go into the body.
     <ProcStep text="Check selector switch continuity">
         Set your multimeter to continuity mode. Move the selector to each of the five positions and verify continuity from SW-OUT to the expected input lug. Position 3 (center) should connect to SW-MP only. Positions 2 and 4 should show continuity to SW-MP and to one adjacent lug.
     </ProcStep>
+    <ProcStep text="Resistance test — verify signal paths">
+        Set your multimeter to resistance (Ω) mode. With volume at maximum, probe between J-TIP and J-SLV. Expected readings by selector position:
+
+        - **Position 1** (Bridge only): ~8.6 kΩ
+        - **Position 2** (Bridge + Middle, parallel): ~4.1 kΩ
+        - **Position 3** (Middle only): ~8.0 kΩ
+        - **Position 4** (Neck + Middle, parallel): ~3.9 kΩ
+        - **Position 5** (Neck only): ~7.6 kΩ
+
+        Open (OL) means a broken connection in that path. A reading much higher than expected in position 2 or 4 (e.g. 16–17 kΩ) suggests the two pickups may be wired in series instead of parallel. Individual pickups can vary ±10% from the spec values above.
+    </ProcStep>
     <ProcStep text="Check for ground shorts on the signal path">
         Probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short.
     </ProcStep>

--- a/content/relay/voicings/lipstick/index.mdx
+++ b/content/relay/voicings/lipstick/index.mdx
@@ -22,15 +22,21 @@ That matters because the guitar still behaves like a familiar two-humbucker inst
 
 <RelayVoicingSection name="controls">
 
-**3-way toggle**
+<ControlPositions switchLabel="3-Way Toggle">
+    <ControlPosition label="1" name="Bridge">
+        Bridge humbucker alone. Tight, defined attack — the most aggressive position.
+    </ControlPosition>
+    <ControlPosition label="2" name="Bridge + Neck">
+        Both humbuckers in parallel. Fuller character with slightly scooped mids.
+    </ControlPosition>
+    <ControlPosition label="3" name="Neck">
+        Neck humbucker alone. Round, warm, and full — the softest position.
+    </ControlPosition>
+</ControlPositions>
 
-1. Bridge
-2. Bridge + neck
-3. Neck
+**Volume (push-push)** — Adds the lipstick shaper. The bridge also gets a partial split and level compensation so the added texture stays integrated.
 
-**Volume (push-push)** - Adds the lipstick shaper. The bridge also gets a partial split and level compensation so the added texture stays integrated.
-
-**Tone (push-pull)** - Alternate voicing contour.
+**Tone (push-pull)** — Alternate voicing contour.
 
 </RelayVoicingSection>
 

--- a/content/relay/voicings/torch/index.mdx
+++ b/content/relay/voicings/torch/index.mdx
@@ -22,15 +22,25 @@ That matters because Torch is not trying to be smooth or neutral. The switch sho
 
 <RelayVoicingSection name="controls">
 
-**5-way blade**
+<ControlPositions switchLabel="5-Way Blade">
+    <ControlPosition label="1" name="Bridge">
+        Bridge humbucker alone. Hot and driven — for heavy rhythm parts and lead.
+    </ControlPosition>
+    <ControlPosition label="2" name="Bridge + Middle">
+        Bridge combined with the Mean 90. Punch with upper-mid push — cuts through a band mix.
+    </ControlPosition>
+    <ControlPosition label="3" name="Middle">
+        Mean 90 alone. The central Torch voice — vocal, punchy, and forward in the mix.
+    </ControlPosition>
+    <ControlPosition label="4" name="Neck + Middle">
+        Neck combined with the Mean 90. Still present but with more warmth and body.
+    </ControlPosition>
+    <ControlPosition label="5" name="Neck">
+        Neck humbucker alone. The most rounded position — usable, but not the defining sound here.
+    </ControlPosition>
+</ControlPositions>
 
-1. Bridge
-2. Bridge + middle
-3. Middle
-4. Neck + middle
-5. Neck
-
-**Tone (push-pull)** - Edge contour.
+**Tone (push-pull)** — Edge contour.
 
 </RelayVoicingSection>
 

--- a/content/relay/voicings/velvet/index.mdx
+++ b/content/relay/voicings/velvet/index.mdx
@@ -24,15 +24,25 @@ That matters because Velvet asks you to use the middle position as a destination
 
 <RelayVoicingSection name="controls">
 
-**5-way blade**
+<ControlPositions switchLabel="5-Way Blade">
+    <ControlPosition label="1" name="Bridge">
+        Bridge humbucker alone. The firmest position — clear attack for rhythm and chord work.
+    </ControlPosition>
+    <ControlPosition label="2" name="Bridge + Middle">
+        Bridge combined with the Retrotron Nashville. Adds warmth and rounds off bridge brightness.
+    </ControlPosition>
+    <ControlPosition label="3" name="Middle">
+        Retrotron Nashville alone. The primary Velvet sound — balanced, controlled, warm, and present.
+    </ControlPosition>
+    <ControlPosition label="4" name="Neck + Middle">
+        Neck combined with the Retrotron. Softer and rounder than position 3, still full.
+    </ControlPosition>
+    <ControlPosition label="5" name="Neck">
+        Neck humbucker alone. Warmest response. Best for chord-melody and full jazz voicings.
+    </ControlPosition>
+</ControlPositions>
 
-1. Bridge
-2. Bridge + middle
-3. Middle
-4. Neck + middle
-5. Neck
-
-**Tone (push-pull)** - Velvet focus contour.
+**Tone (push-pull)** — Velvet focus contour.
 
 </RelayVoicingSection>
 

--- a/templates/relay/relay-bom.mdx
+++ b/templates/relay/relay-bom.mdx
@@ -1,0 +1,58 @@
+---
+title: 'Supply List'
+description: 'Everything you need to build a Relay [Model Name], with sourcing links and current prices.'
+---
+
+Read this before you buy anything. Items marked **Specific** mean that exact part — don't swap it out. Items marked **Flexible** have a real alternative listed below them.
+
+<DecisionNote variant="info" title="These are the parts I actually use.">
+    I've linked to exactly what I build with. When something is marked Flexible, I'll tell you what the tradeoff is so you can decide. When it's marked Specific, I've already learned that lesson the hard way.
+</DecisionNote>
+
+## Hardware
+
+<BomSection>
+    <BomItem title="Guitar Neck" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="guitar-neck" fallback="$0.00">
+        [Notes about neck fit, variations, or what to watch for. Or remove children if no notes needed.]
+    </BomItem>
+    <BomItem title="Fixed Hardtail Bridge" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="hardtail-bridge" fallback="$0.00" />
+    <BomItem title="Neck Mounting Ferrules" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="neck-ferrules" fallback="$0.00" />
+    <BomItem title="String Ferrule Plate" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="string-ferrule-plate" fallback="$0.00" substitution="[Describe the alternative and when it makes sense to use it]" />
+    <BomItem title="Locking Tuners" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="locking-tuners" fallback="$0.00" substitution="Standard non-locking tuners work fine. Slightly slower restringing and marginally less tuning stability while strings settle." />
+    <BomItem title="Strap Buttons" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="strap-buttons" fallback="$0.00" substitution="Any standard strap button fits. Use your existing strap locks if preferred." />
+    <BomItem title="Guitar Strings (9–42), 3-pack" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="guitar-strings" fallback="$0.00" substitution="Any 9–42 light gauge strings work. Stick with 9s until the instrument is dialed in.">
+        Three packs because you'll break at least one string during setup.
+    </BomItem>
+    <BomItem title="Knobs" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="knobs" fallback="$0.00" substitution="Any knob that fits a split-shaft pot. Check shaft diameter before buying." />
+</BomSection>
+
+## Pickups
+
+<BomSection>
+    <BomItem title="Neck Pickup — [Model]" href="[URL]" source="[Vendor]" itemKey="[model-slug]-neck-pickup" fallback="$0.00" specific>
+        [Why this specific pickup? What happens to the voicing balance if someone substitutes it?]
+    </BomItem>
+    <BomItem title="Middle Pickup — [Model]" href="[URL]" source="[Vendor]" itemKey="[model-slug]-middle-pickup" fallback="$0.00" specific>
+        [Role this pickup plays in the circuit. What constraints apply to substitutions?]
+    </BomItem>
+    <BomItem title="Bridge Pickup — [Model]" href="[URL]" source="[Vendor]" itemKey="[model-slug]-bridge-pickup" fallback="$0.00" specific>
+        [Describe output range or impedance constraints if high-output substitutions are a concern.]
+    </BomItem>
+</BomSection>
+
+## Electronics
+
+<BomSection>
+    <BomItem title="[Volume pot type — e.g., Push-Push Pots (×2)]" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="[model-slug]-volume-pots" fallback="$0.00" substitution="[Describe what the builder loses by using standard pots instead]">
+        [Describe what the special pot function does in this voicing]
+    </BomItem>
+    <BomItem title="Selector Switch ([type]-way)" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="[model-slug]-selector-switch" fallback="$0.00" specific>
+        [Note the exact type required — 3-way or 5-way. Call out if it matters which blade style.]
+    </BomItem>
+    <BomItem title="Tone Capacitor" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="[model-slug]-tone-cap" fallback="$0.00" substitution="Cap value is tonal preference. Listed value gives a warm but not muddy roll-off. Smaller = cuts higher frequencies; larger = cuts lower. Caps are cheap — experiment." />
+    <BomItem title="Output Jack" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="[model-slug]-output-jack" fallback="$0.00" substitution='Any standard 1/4" mono output jack works. Measure the cavity opening if substituting.' />
+    <BomItem title="Hookup Wire" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="hookup-wire" fallback="$0.00" substitution="Any 22–24 AWG stranded hookup wire. Avoid solid core — it's harder to route in tight spaces and fatigues with vibration." />
+    <BomItem title="Copper Foil Tape" href="https://amzn.to/[affiliate-id]" source="Amazon" itemKey="copper-foil-tape" fallback="$0.00" specific>
+        Used to shield the control cavity. Must be conductive adhesive type. Non-conductive adhesive tape won't ground the foil.
+    </BomItem>
+</BomSection>

--- a/templates/relay/relay-voice.mdx
+++ b/templates/relay/relay-voice.mdx
@@ -1,0 +1,61 @@
+---
+title: 'Relay [Model Name]'
+description: '[One sentence describing this voicing for search results and meta tags]'
+voicing: '[model-slug]'
+---
+
+<RelayVoicingSection name="what-it-is">
+
+[2–3 sentences on what this guitar sounds like. What's the character? What makes it distinctive? Write this as the elevator pitch for the voicing — what would make someone choose this one over the others.]
+
+</RelayVoicingSection>
+
+<RelayVoicingSection name="pickup-interaction">
+
+**Category:** [Shaper / Subsystem / Primary voice / Augment layer]
+
+[Explain how the pickups work together. Does the middle pickup act as a standalone voice or modify the selected humbucker? Is this a traditional switching scheme or something unusual? What does the player need to understand about the pickup interaction before they start playing?]
+
+</RelayVoicingSection>
+
+<RelayVoicingSection name="controls">
+
+<ControlPositions switchLabel="[Switch type — e.g., 3-Way Toggle / 5-Way Blade]">
+    <ControlPosition label="1" name="[Position 1 name — e.g., Bridge]">
+        [What does this position sound like? What does the player get? 1–2 sentences.]
+    </ControlPosition>
+    <ControlPosition label="2" name="[Position 2 name]">
+        [Description]
+    </ControlPosition>
+    <ControlPosition label="3" name="[Position 3 name]">
+        [Description]
+    </ControlPosition>
+</ControlPositions>
+
+**Volume** — [Describe any special function, e.g., "Push-push engages the lipstick shaper." Or just "Master volume."]
+
+**Tone** — [Describe any special function, e.g., "Push-pull switches to alternate voicing contour." Or just "Standard tone control."]
+
+</RelayVoicingSection>
+
+<RelayVoicingSection name="how-it-behaves">
+
+[Describe what it feels and sounds like to actually play through the switch positions. What changes between positions? What stays consistent? What should the player expect when they first pick it up?]
+
+[Tell them which positions are the most versatile vs. the most specialized. Give them a mental model for how to use the controls productively.]
+
+</RelayVoicingSection>
+
+<RelayVoicingSection name="who-its-for">
+
+[Genre, style, and player type. 1–2 sentences. Who is this for and what will they get out of it? What gear context does it excel in — clean amps, pedal platform, studio tracking, live stage?]
+
+</RelayVoicingSection>
+
+<RelayVoicingPickupChoices neck="[Neck pickup full name]" middle="[Middle pickup full name, or remove this prop if no middle]" bridge="[Bridge pickup full name]">
+
+[Substitution guidance. What should the builder keep in mind if swapping parts? Are there output level, impedance, or voicing constraints that matter for this design? If substitutions are not recommended for a specific pickup, say why clearly.]
+
+</RelayVoicingPickupChoices>
+
+<RelayDiscordCta message="Building a [Model Name]? Share your progress and ask questions in the Discord." />

--- a/templates/relay/relay-wiring.mdx
+++ b/templates/relay/relay-wiring.mdx
@@ -1,0 +1,107 @@
+---
+title: 'Wiring Guide'
+description: 'Step-by-step wiring instructions for the Relay [Model Name].'
+---
+
+[1–2 sentence overview of what this wiring accomplishes and any special features of this model's circuit. If there's something unusual about this voicing's wiring versus a standard guitar, mention it here.]
+
+<DocAlert level="Important" title="Read before you start">
+    Solder the ground bus and shield the cavity before installing any components. Shielding after assembly is miserable and the lipstick pickup is sensitive to interference.
+</DocAlert>
+
+## Component Labels
+
+Every connection point in this guide has a short label. Use the table below as a reference while wiring — the same labels appear on the component diagram above.
+
+<DocImage
+    title="[Model Name] Wiring Diagram"
+    src="/images/relay/[model-slug]/wiring-diagram.png"
+    alt="Labeled wiring diagram showing all connection points for the Relay [Model Name]"
+    triggerImageSize={300}
+    popupImageSize={1200}
+/>
+
+<ComponentLabels>
+    <ComponentLabel id="NP-H" component="Neck Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="NP-G" component="Neck Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="BP-H" component="Bridge Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="BP-G" component="Bridge Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="SW-C" component="Selector Switch" description="Common lug (output of switch)" />
+    <ComponentLabel id="SW-1" component="Selector Switch" description="Position 1 lug" />
+    <ComponentLabel id="SW-2" component="Selector Switch" description="Position 2 lug" />
+    <ComponentLabel id="SW-3" component="Selector Switch" description="Position 3 lug" />
+    <ComponentLabel id="VOL-IN" component="Volume Pot" description="Input lug — signal in from switch" />
+    <ComponentLabel id="VOL-W" component="Volume Pot" description="Wiper (center lug) — signal out to jack" />
+    <ComponentLabel id="VOL-B" component="Volume Pot" description="Back of pot — connect to ground bus" />
+    <ComponentLabel id="TON-IN" component="Tone Pot" description="Input lug — tapped from VOL-IN" />
+    <ComponentLabel id="TON-B" component="Tone Pot" description="Back of pot — connect to ground bus" />
+    <ComponentLabel id="CAP-H" component="Tone Capacitor" description="Hot leg — connects to TON-IN" />
+    <ComponentLabel id="CAP-G" component="Tone Capacitor" description="Ground leg — connects to ground bus" />
+    <ComponentLabel id="J-TIP" component="Output Jack" description="Tip lug (hot signal to amp)" />
+    <ComponentLabel id="J-SLV" component="Output Jack" description="Sleeve lug (ground)" />
+    <ComponentLabel id="GND" component="Ground Bus" description="Common ground — cavity foil, pot backs, jack sleeve, pickup grounds" />
+</ComponentLabels>
+
+## Connections
+
+Make all of these connections. Order doesn't matter — do whichever is easiest to reach first. Each row tells you which two labeled points to connect with a length of hookup wire.
+
+<WiringConnections>
+    <WireConnection from="NP-H" to="SW-[n]" notes="Neck pickup hot to switch position [n]" />
+    <WireConnection from="BP-H" to="SW-[n]" notes="Bridge pickup hot to switch position [n]" />
+    <WireConnection from="SW-C" to="VOL-IN" notes="Switch output to volume input" />
+    <WireConnection from="VOL-IN" to="TON-IN" notes="Tap from volume input to tone pot input" />
+    <WireConnection from="VOL-W" to="J-TIP" notes="Volume wiper to jack tip" />
+    <WireConnection from="CAP-H" to="TON-IN" notes="" />
+    <WireConnection from="NP-G" to="GND" notes="" />
+    <WireConnection from="BP-G" to="GND" notes="" />
+    <WireConnection from="VOL-B" to="GND" notes="" />
+    <WireConnection from="TON-B" to="GND" notes="" />
+    <WireConnection from="CAP-G" to="GND" notes="" />
+    <WireConnection from="J-SLV" to="GND" notes="" />
+</WiringConnections>
+
+## Wiring Procedure
+
+<Proc title="Wiring Steps">
+    <ProcStep text="Shield the cavity">
+        Apply copper foil tape to all cavity walls and the floor before installing any components. Overlap foil sections by at least 2mm for continuity. Solder a short jumper wire across any gap between sections that don't overlap. Connect the foil to the ground bus with a short wire soldered to the foil surface.
+    </ProcStep>
+    <ProcStep text="Pre-tin all solder points">
+        Apply a small dot of solder to every lug and pad before making any connections. Pre-tinning makes the final joints faster, uses less heat on the components, and gives you cleaner joints.
+    </ProcStep>
+    <ProcStep text="[Step 3 — e.g., Wire the selector switch]">
+        [Instructions for this step. Keep each step focused on one component or one logical group of connections.]
+    </ProcStep>
+    <ProcStep text="[Step 4 — e.g., Wire the ground bus]">
+        [Instructions]
+    </ProcStep>
+    <ProcStep text="[Step 5 — e.g., Connect the volume and tone pots]">
+        [Instructions]
+    </ProcStep>
+    <ProcStep text="[Step 6 — e.g., Connect the output jack]">
+        [Instructions]
+    </ProcStep>
+    <ProcStep text="[Step N — Any model-specific step]">
+        [Instructions for any wiring step unique to this voicing — push-push function, blend circuit, coil tap, etc.]
+    </ProcStep>
+</Proc>
+
+## Pre-Installation Test
+
+Test everything on the bench before the components go into the body. Probing and adjusting is much easier when nothing is bolted down.
+
+<Proc title="Bench Test">
+    <ProcStep text="Check selector switch continuity">
+        Set your multimeter to continuity mode. Move the switch to each position and probe between SW-C and each position lug. You should get continuity only to the lug for the currently selected position, and no continuity to the others.
+    </ProcStep>
+    <ProcStep text="Check for ground shorts on the signal path">
+        With the multimeter still in continuity mode, probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short that will kill your signal — find and fix it before proceeding.
+    </ProcStep>
+    <ProcStep text="Tap test each pickup">
+        Plug a cable into J-TIP and into an amp at low volume. Hold a metal screwdriver near each pickup and tap the pole pieces — you should hear a clear thunk through the amp for each tap. Move the selector switch through all positions and verify the correct pickup responds in each position.
+    </ProcStep>
+    <ProcStep text="[Model-specific test, if applicable]">
+        [Describe any test that's specific to this voicing — e.g., verifying push-push function, blend circuit behavior, or coil split continuity. Remove this step if not applicable.]
+    </ProcStep>
+</Proc>


### PR DESCRIPTION
## Summary

- Adds three new MDX-usable doc components: `ControlPositions/ControlPosition`, `ComponentLabels/ComponentLabel`, and `WiringConnections/WireConnection`
- Registers all six exports in `mdx-components.tsx` so they're available in any MDX file
- Creates three authoring templates in `templates/relay/` as copy-and-fill starting points for each model's documentation pages

## Components

**`ControlPositions` / `ControlPosition`** — Structured switch position cards with numbered indigo badges. Used inside the `controls` section of a voice page to clearly document what each selector position sounds like.

**`ComponentLabels` / `ComponentLabel`** — A reference table for the wiring label system. Each row shows a short code (e.g. `NP-H`), the component name, a wire color swatch, and a description. This table is the single source of truth for labels — the diagram image annotations should match these IDs exactly.

**`WiringConnections` / `WireConnection`** — A connection table that maps `from` labels to `to` labels using monospace code badges. All data lives in the MDX.

## Templates

| File | Purpose |
|------|---------|
| `templates/relay/relay-voice.mdx` | Voice character, controls, audience, pickup choices |
| `templates/relay/relay-bom.mdx` | Parts list using existing BomSection/BomItem pattern |
| `templates/relay/relay-wiring.mdx` | Component labels, connection table, wiring procedure, bench test |

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit` — only pre-existing deprecation warning, no new errors)
- [ ] New components appear in mdx-components.tsx and are usable in any MDX file
- [ ] Templates in `templates/relay/` are outside the content pipeline and won't be served as pages

https://claude.ai/code/session_013PU4ZwxFQ8Qin7zDZMvxsM

---
_Generated by [Claude Code](https://claude.ai/code/session_013PU4ZwxFQ8Qin7zDZMvxsM)_