### PR TITLE
Add serialized guitar records and printable case cards

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "extends": ["next/core-web-vitals", "plugin:jsx-a11y/recommended", "prettier"],
     "env": {
         "browser": true,

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ next-env.d.ts
 sitemap*.xml
 robots.txt
 .superpowers/
+.worktrees/

--- a/.remember/remember.md
+++ b/.remember/remember.md
@@ -1,0 +1,12 @@
+# Handoff
+
+## State
+I implemented serialized instrument records and printable case cards on `codex/instrument-records` in `.worktrees/instrument-records`. The approved spec and tracked plan are in `docs/superpowers/`; the unpublished authoring template is `content/instruments/RLY26001.mdx`.
+
+## Next
+1. Replace the template photograph/copy with the first real instrument record.
+2. Check Letter/A4 print preview and scan the QR before setting `publish: true`.
+3. Merge or PR `codex/instrument-records` after user review.
+
+## Context
+The card is sized to A4 printable width × Letter printable height and prioritizes complete control/voice access. Web records retain the standard header/footer; owner data and PDF generation are intentionally out of scope.

--- a/app/sn/[serial]/page.tsx
+++ b/app/sn/[serial]/page.tsx
@@ -4,6 +4,7 @@ import { MDXRemote } from 'next-mdx-remote/rsc';
 import { InstrumentRecordPage } from '@/components/instrument/instrument-record-page';
 import { instrumentMdxComponents } from '@/components/instrument/instrument-mdx-components';
 import { getInstrument, getInstrumentStaticParams } from '@/lib/instruments/records';
+import { resolveInstrumentRequest } from '@/lib/instruments/route-resolution';
 import { instrumentUrl, normalizeInstrumentSerial } from '@/lib/instruments/serial';
 import { isInstrumentPublished } from '@/lib/instruments/visibility';
 
@@ -31,12 +32,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function InstrumentPage({ params }: Props) {
     const { serial: input } = await params;
-    const serial = normalizeInstrumentSerial(input);
+    const resolution = resolveInstrumentRequest(input, process.env.NODE_ENV, getInstrument);
 
-    if (input !== serial) redirect(`/sn/${serial}`);
-
-    const record = getInstrument(serial);
-    if (!record || !isInstrumentPublished(record)) notFound();
+    if (resolution.kind === 'redirect') redirect(resolution.location);
+    if (resolution.kind === 'not-found') notFound();
+    const { record } = resolution;
 
     return (
         <InstrumentRecordPage record={record}>

--- a/app/sn/[serial]/page.tsx
+++ b/app/sn/[serial]/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import { InstrumentRecordPage } from '@/components/instrument/instrument-record-page';
+import { instrumentMdxComponents } from '@/components/instrument/instrument-mdx-components';
+import { getInstrument, getInstrumentStaticParams } from '@/lib/instruments/records';
+import { instrumentUrl, normalizeInstrumentSerial } from '@/lib/instruments/serial';
+import { isInstrumentPublished } from '@/lib/instruments/visibility';
+
+interface Props {
+    params: Promise<{ serial: string }>;
+}
+
+export function generateStaticParams() {
+    return getInstrumentStaticParams();
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { serial: input } = await params;
+    const serial = normalizeInstrumentSerial(input);
+    const record = getInstrument(serial);
+
+    if (!record || !isInstrumentPublished(record)) return {};
+
+    return {
+        title: `${record.name} · ${serial} | K7RHY`,
+        description: record.theme,
+        alternates: { canonical: instrumentUrl(serial) },
+    };
+}
+
+export default async function InstrumentPage({ params }: Props) {
+    const { serial: input } = await params;
+    const serial = normalizeInstrumentSerial(input);
+
+    if (input !== serial) redirect(`/sn/${serial}`);
+
+    const record = getInstrument(serial);
+    if (!record || !isInstrumentPublished(record)) notFound();
+
+    return (
+        <InstrumentRecordPage record={record}>
+            <MDXRemote source={record.content} components={instrumentMdxComponents} />
+        </InstrumentRecordPage>
+    );
+}

--- a/app/sn/[serial]/print/page.tsx
+++ b/app/sn/[serial]/print/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import { InstrumentCaseCard } from '@/components/instrument/instrument-case-card';
+import { instrumentMdxComponents } from '@/components/instrument/instrument-mdx-components';
+import { PrintCaseCardControls } from '@/components/instrument/print-case-card-controls';
+import { getInstrument, getInstrumentStaticParams } from '@/lib/instruments/records';
+import { normalizeInstrumentSerial } from '@/lib/instruments/serial';
+import { isInstrumentPublished } from '@/lib/instruments/visibility';
+
+interface Props {
+    params: Promise<{ serial: string }>;
+}
+
+export function generateStaticParams() {
+    return getInstrumentStaticParams();
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { serial: input } = await params;
+    const serial = normalizeInstrumentSerial(input);
+    const record = getInstrument(serial);
+
+    if (!record || !isInstrumentPublished(record)) return { robots: { index: false, follow: false } };
+
+    return {
+        title: `Case card · ${record.name} · ${serial} | K7RHY`,
+        robots: { index: false, follow: false },
+    };
+}
+
+export default async function InstrumentPrintPage({ params }: Props) {
+    const { serial: input } = await params;
+    const serial = normalizeInstrumentSerial(input);
+
+    if (input !== serial) redirect(`/sn/${serial}/print`);
+
+    const record = getInstrument(serial);
+    if (!record || !isInstrumentPublished(record)) notFound();
+
+    return (
+        <main>
+            <PrintCaseCardControls />
+            <InstrumentCaseCard record={record}>
+                <div className="instrument-print-mdx">
+                    <MDXRemote source={record.content} components={instrumentMdxComponents} />
+                </div>
+            </InstrumentCaseCard>
+        </main>
+    );
+}

--- a/app/sn/[serial]/print/page.tsx
+++ b/app/sn/[serial]/print/page.tsx
@@ -5,6 +5,7 @@ import { InstrumentCaseCard } from '@/components/instrument/instrument-case-card
 import { instrumentMdxComponents } from '@/components/instrument/instrument-mdx-components';
 import { PrintCaseCardControls } from '@/components/instrument/print-case-card-controls';
 import { getInstrument, getInstrumentStaticParams } from '@/lib/instruments/records';
+import { resolveInstrumentRequest } from '@/lib/instruments/route-resolution';
 import { normalizeInstrumentSerial } from '@/lib/instruments/serial';
 import { isInstrumentPublished } from '@/lib/instruments/visibility';
 
@@ -31,12 +32,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function InstrumentPrintPage({ params }: Props) {
     const { serial: input } = await params;
-    const serial = normalizeInstrumentSerial(input);
+    const resolution = resolveInstrumentRequest(input, process.env.NODE_ENV, getInstrument);
 
-    if (input !== serial) redirect(`/sn/${serial}/print`);
-
-    const record = getInstrument(serial);
-    if (!record || !isInstrumentPublished(record)) notFound();
+    if (resolution.kind === 'redirect') redirect(`${resolution.location}/print`);
+    if (resolution.kind === 'not-found') notFound();
+    const { record } = resolution;
 
     return (
         <main>

--- a/app/sn/instrument-records.css
+++ b/app/sn/instrument-records.css
@@ -4,7 +4,7 @@
 }
 
 .instrument-case-card {
-    width: min(calc(100% - 2rem), 7.8in);
+    width: min(calc(100% - 2rem), 7.57in);
     min-height: 10.3in;
     margin: 1.5rem auto;
 }
@@ -13,13 +13,23 @@
 .instrument-case-card-spec [data-pickup-configuration] {
     border-color: rgb(203 213 225);
     border-radius: 0.65rem;
-    padding: 0.14in;
+    background: white !important;
+    color: rgb(15 23 42) !important;
+    padding: 0.085in;
     box-shadow: none;
+}
+
+.instrument-case-card-spec [data-instrument-spec] > * + * {
+    margin-top: 0.07in !important;
+}
+
+.instrument-case-card-spec [data-control-layout] > .space-y-4 > * + * {
+    margin-top: 0.045in !important;
 }
 
 .instrument-case-card-spec [data-control-layout] > div:first-child,
 .instrument-case-card-spec [data-pickup-configuration] > div:first-child {
-    margin-bottom: 0.1in;
+    margin-bottom: 0.065in;
 }
 
 .instrument-case-card-spec [data-control-layout] > div:first-child > span,
@@ -29,18 +39,41 @@
 
 .instrument-case-card-spec [data-control-layout] h2,
 .instrument-case-card-spec [data-pickup-configuration] h2 {
-    font-size: 12pt;
+    font-size: 11pt;
 }
 
 .instrument-case-card-spec [data-control-layout] article,
 .instrument-case-card-spec [data-pickup-configuration] article {
     border-color: rgb(203 213 225);
     border-radius: 0.45rem;
-    padding: 0.1in;
+    background: rgb(248 250 252) !important;
+    color: rgb(15 23 42) !important;
+    padding: 0.055in;
+}
+
+.instrument-case-card-spec [data-control-layout] ol,
+.instrument-case-card-spec [data-control-layout] article > div.grid,
+.instrument-case-card-spec [data-pickup-configuration] > div.grid {
+    gap: 0.05in !important;
+}
+
+.instrument-case-card-spec [data-control-layout] li,
+.instrument-case-card-spec [data-control-layout] article > div.grid > div {
+    border-color: rgb(203 213 225) !important;
+    background: rgb(248 250 252) !important;
+    color: rgb(15 23 42) !important;
+    padding: 0.055in !important;
+}
+
+.instrument-case-card-spec [data-control-layout] li > div:first-child {
+    width: 0.24in !important;
+    height: 0.24in !important;
+    margin-bottom: 0.025in !important;
 }
 
 .instrument-case-card-spec [data-control-layout] h3,
 .instrument-case-card-spec [data-pickup-configuration] h3 {
+    color: rgb(15 23 42) !important;
     font-size: 9pt;
 }
 
@@ -49,8 +82,13 @@
 .instrument-case-card-spec [data-pickup-configuration] p,
 .instrument-case-card-spec [data-pickup-configuration] dt,
 .instrument-case-card-spec [data-pickup-configuration] dd {
+    color: rgb(71 85 105) !important;
     font-size: 8pt;
-    line-height: 1.3;
+    line-height: 1.25;
+}
+
+.instrument-print-mdx > :not([data-instrument-spec]) {
+    display: none !important;
 }
 
 @media print {
@@ -84,12 +122,9 @@
         -webkit-print-color-adjust: exact;
     }
 
-    .instrument-print-mdx > :not([data-instrument-spec]) {
-        display: none !important;
-    }
 }
 
-@media (max-width: 50rem) {
+@media screen and (max-width: 50rem) {
     .instrument-case-card {
         width: calc(100% - 1rem);
         min-height: auto;

--- a/app/sn/instrument-records.css
+++ b/app/sn/instrument-records.css
@@ -1,5 +1,5 @@
 @page {
-    size: letter portrait;
+    size: auto;
     margin: 0.35in;
 }
 
@@ -106,14 +106,23 @@
 
     main:has(.instrument-case-card) {
         display: block;
+        position: relative;
+        width: 7.2in;
+        height: 9.8in;
+        margin: 0 auto;
     }
 
     .instrument-case-card {
-        width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 7.57in;
         min-height: 0;
         height: 10.3in;
         margin: 0;
         overflow: hidden;
+        transform: scale(0.95);
+        transform-origin: top left;
         break-after: avoid;
         break-inside: avoid;
         border-color: rgb(148 163 184);

--- a/app/sn/instrument-records.css
+++ b/app/sn/instrument-records.css
@@ -1,0 +1,98 @@
+@page {
+    size: letter portrait;
+    margin: 0.35in;
+}
+
+.instrument-case-card {
+    width: min(calc(100% - 2rem), 7.8in);
+    min-height: 10.3in;
+    margin: 1.5rem auto;
+}
+
+.instrument-case-card-spec [data-control-layout],
+.instrument-case-card-spec [data-pickup-configuration] {
+    border-color: rgb(203 213 225);
+    border-radius: 0.65rem;
+    padding: 0.14in;
+    box-shadow: none;
+}
+
+.instrument-case-card-spec [data-control-layout] > div:first-child,
+.instrument-case-card-spec [data-pickup-configuration] > div:first-child {
+    margin-bottom: 0.1in;
+}
+
+.instrument-case-card-spec [data-control-layout] > div:first-child > span,
+.instrument-case-card-spec [data-pickup-configuration] > div:first-child > span {
+    display: none;
+}
+
+.instrument-case-card-spec [data-control-layout] h2,
+.instrument-case-card-spec [data-pickup-configuration] h2 {
+    font-size: 12pt;
+}
+
+.instrument-case-card-spec [data-control-layout] article,
+.instrument-case-card-spec [data-pickup-configuration] article {
+    border-color: rgb(203 213 225);
+    border-radius: 0.45rem;
+    padding: 0.1in;
+}
+
+.instrument-case-card-spec [data-control-layout] h3,
+.instrument-case-card-spec [data-pickup-configuration] h3 {
+    font-size: 9pt;
+}
+
+.instrument-case-card-spec [data-control-layout] p,
+.instrument-case-card-spec [data-control-layout] div,
+.instrument-case-card-spec [data-pickup-configuration] p,
+.instrument-case-card-spec [data-pickup-configuration] dt,
+.instrument-case-card-spec [data-pickup-configuration] dd {
+    font-size: 8pt;
+    line-height: 1.3;
+}
+
+@media print {
+    html,
+    body {
+        background: white !important;
+    }
+
+    [data-site-header],
+    [data-site-footer],
+    .instrument-print-controls,
+    [data-web-only] {
+        display: none !important;
+    }
+
+    main:has(.instrument-case-card) {
+        display: block;
+    }
+
+    .instrument-case-card {
+        width: 100%;
+        min-height: 0;
+        height: 10.3in;
+        margin: 0;
+        overflow: hidden;
+        break-after: avoid;
+        break-inside: avoid;
+        border-color: rgb(148 163 184);
+        box-shadow: none;
+        print-color-adjust: exact;
+        -webkit-print-color-adjust: exact;
+    }
+
+    .instrument-print-mdx > :not([data-instrument-spec]) {
+        display: none !important;
+    }
+}
+
+@media (max-width: 50rem) {
+    .instrument-case-card {
+        width: calc(100% - 1rem);
+        min-height: auto;
+        padding: 1.25rem;
+    }
+}

--- a/app/sn/instrument-records.test.ts
+++ b/app/sn/instrument-records.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(join(process.cwd(), 'app/sn/instrument-records.css'), 'utf8');
+
+describe('instrument case-card print geometry', () => {
+    it('fits Letter and A4 at 100% with printer-safe tolerance', () => {
+        expect(css).toMatch(/@page\s*{[^}]*size:\s*auto;/s);
+        expect(css).toMatch(/@media print[\s\S]*?main:has\(\.instrument-case-card\)\s*{[\s\S]*?width:\s*7\.2in;[\s\S]*?height:\s*9\.8in;/);
+        expect(css).toMatch(/@media print[\s\S]*?\.instrument-case-card\s*{[\s\S]*?width:\s*7\.57in;[\s\S]*?height:\s*10\.3in;[\s\S]*?transform:\s*scale\(0\.95\);/);
+    });
+});

--- a/app/sn/layout.tsx
+++ b/app/sn/layout.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import './instrument-records.css';
+
+export default function InstrumentLayout({ children }: { children: React.ReactNode }) {
+    return children;
+}

--- a/components/instrument/instrument-case-card.test.tsx
+++ b/components/instrument/instrument-case-card.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { InstrumentCaseCard } from './instrument-case-card';
+import type { InstrumentRecord } from '@/types/instrument';
+
+vi.mock('next/image', () => ({
+    default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
+}));
+
+vi.mock('qrcode.react', () => ({
+    QRCodeSVG: ({ value }: { value: string }) => <svg aria-label="Instrument record QR code" data-value={value} />,
+}));
+
+const record: InstrumentRecord = {
+    serial: 'RLY26001',
+    modelCode: 'RLY',
+    modelDescription: 'Relay',
+    year: 2026,
+    index: 1,
+    publish: true,
+    name: 'Relay Lipstick',
+    completed: '2026-06-19',
+    origin: 'Built by K7RHY Resonance Lab.',
+    theme: 'Articulate and touch-sensitive.',
+    images: [{ src: '/front.jpg', alt: 'Front' }],
+    content: '',
+};
+
+describe('InstrumentCaseCard', () => {
+    it('renders the site logo and full brand name', () => {
+        render(
+            <InstrumentCaseCard record={record}>
+                <div>Control map</div>
+            </InstrumentCaseCard>,
+        );
+
+        expect(screen.getByRole('img', { name: 'K7RHY Resonance Lab logo' })).toBeInTheDocument();
+        expect(screen.getByText('K7RHY Resonance Lab')).toBeInTheDocument();
+    });
+
+    it('renders identity, controls, Discord, and canonical QR destination without the guitar photo', () => {
+        const { container } = render(
+            <InstrumentCaseCard record={record}>
+                <div>Control map</div>
+            </InstrumentCaseCard>,
+        );
+
+        expect(container).toHaveTextContent('RLY26001');
+        expect(screen.getByText('Control map')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /discord/i })).toHaveAttribute('href', 'https://discord.gg/BuUxCG4W6w');
+        expect(container.querySelector('[data-value="https://k7rhy.app/sn/RLY26001"]')).toBeInTheDocument();
+        expect(container.querySelector('img[src="/front.jpg"]')).not.toBeInTheDocument();
+    });
+});

--- a/components/instrument/instrument-case-card.tsx
+++ b/components/instrument/instrument-case-card.tsx
@@ -10,10 +10,10 @@ export function InstrumentCaseCard({ record, children }: { record: InstrumentRec
     const url = instrumentUrl(record.serial);
 
     return (
-        <article className="instrument-case-card flex flex-col border border-slate-300 bg-white p-[0.32in] text-slate-950 shadow-xl">
-            <header className="flex items-center justify-between gap-4 border-b border-slate-300 pb-4">
+        <article className="instrument-case-card flex flex-col border border-slate-300 bg-white p-[0.26in] text-slate-950 shadow-xl">
+            <header className="flex items-center justify-between gap-4 border-b border-slate-300 pb-3">
                 <div className="flex items-center gap-3">
-                    <Image src="/images/k7rhy_logo.png" alt="K7RHY Resonance Lab logo" width={46} height={46} className="h-11 w-11 object-contain" />
+                    <Image src="/images/k7rhy_logo.png" alt="K7RHY Resonance Lab logo" width={42} height={42} className="h-10 w-10 object-contain" />
                     <div>
                         <p className="text-base font-bold tracking-tight">K7RHY Resonance Lab</p>
                         <p className="font-mono text-[7.5pt] uppercase tracking-[0.16em] text-slate-500">Crafted instrument record</p>
@@ -22,23 +22,23 @@ export function InstrumentCaseCard({ record, children }: { record: InstrumentRec
                 <span className="text-right font-mono text-[8pt] font-semibold uppercase tracking-[0.16em] text-slate-500">Voice &amp;<br />control card</span>
             </header>
 
-            <section className="relative overflow-hidden py-5">
+            <section className="relative overflow-hidden py-4">
                 <div className="pointer-events-none absolute -right-16 -top-28 h-52 w-52 rounded-full border border-sky-200 shadow-[0_0_0_18px_#f0f9ff,0_0_0_36px_#f8fafc]" />
                 <div className="relative">
                     <div className="font-mono text-[8.5pt] font-semibold tracking-[0.14em] text-sky-700">{record.serial} · COMPLETED {record.year}</div>
-                    <h1 className="mt-1 text-[25pt] font-semibold leading-none tracking-tight">{record.name}</h1>
-                    <p className="mt-3 max-w-[6.3in] text-[9.5pt] leading-relaxed text-slate-600">{record.theme}</p>
+                    <h1 className="mt-1 text-[23pt] font-semibold leading-none tracking-tight">{record.name}</h1>
+                    <p className="mt-2 max-w-[6.3in] text-[9pt] leading-relaxed text-slate-600">{record.theme}</p>
                 </div>
             </section>
 
             <section className="instrument-case-card-spec min-h-0 flex-1">{children}</section>
 
-            <section className="mt-4 grid grid-cols-[0.85in_1fr] gap-3 border-t border-slate-300 pt-3 text-[8.5pt] leading-relaxed">
+            <section className="mt-3 grid grid-cols-[0.85in_1fr] gap-3 border-t border-slate-300 pt-2 text-[8.5pt] leading-relaxed">
                 <span className="font-mono text-[7.5pt] font-semibold uppercase tracking-wider text-slate-500">Origin</span>
                 <span>{record.origin}</span>
             </section>
 
-            <footer className="mt-4 flex items-end justify-between gap-4 border-t border-slate-300 pt-4">
+            <footer className="mt-3 flex items-end justify-between gap-4 border-t border-slate-300 pt-3">
                 <div className="space-y-2 text-slate-600">
                     <p className="font-mono text-[7.5pt] tracking-wide">{url}</p>
                     <a href={siteConfig.links.discord} className="inline-flex items-center gap-1.5 text-[8.5pt] font-semibold text-slate-800 underline decoration-sky-500 underline-offset-2">
@@ -47,7 +47,7 @@ export function InstrumentCaseCard({ record, children }: { record: InstrumentRec
                     </a>
                 </div>
                 <div className="rounded-md border border-slate-300 bg-white p-1.5">
-                    <QRCodeSVG value={url} size={82} level="M" marginSize={1} title={`Open the record for ${record.serial}`} />
+                    <QRCodeSVG value={url} size={72} level="M" marginSize={1} title={`Open the record for ${record.serial}`} />
                 </div>
             </footer>
         </article>

--- a/components/instrument/instrument-case-card.tsx
+++ b/components/instrument/instrument-case-card.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Image from 'next/image';
+import { QRCodeSVG } from 'qrcode.react';
+import { MessageCircle } from 'lucide-react';
+import { siteConfig } from '@/config/site';
+import { instrumentUrl } from '@/lib/instruments/serial';
+import type { InstrumentRecord } from '@/types/instrument';
+
+export function InstrumentCaseCard({ record, children }: { record: InstrumentRecord; children: React.ReactNode }) {
+    const url = instrumentUrl(record.serial);
+
+    return (
+        <article className="instrument-case-card flex flex-col border border-slate-300 bg-white p-[0.32in] text-slate-950 shadow-xl">
+            <header className="flex items-center justify-between gap-4 border-b border-slate-300 pb-4">
+                <div className="flex items-center gap-3">
+                    <Image src="/images/k7rhy_logo.png" alt="K7RHY Resonance Lab logo" width={46} height={46} className="h-11 w-11 object-contain" />
+                    <div>
+                        <p className="text-base font-bold tracking-tight">K7RHY Resonance Lab</p>
+                        <p className="font-mono text-[7.5pt] uppercase tracking-[0.16em] text-slate-500">Crafted instrument record</p>
+                    </div>
+                </div>
+                <span className="text-right font-mono text-[8pt] font-semibold uppercase tracking-[0.16em] text-slate-500">Voice &amp;<br />control card</span>
+            </header>
+
+            <section className="relative overflow-hidden py-5">
+                <div className="pointer-events-none absolute -right-16 -top-28 h-52 w-52 rounded-full border border-sky-200 shadow-[0_0_0_18px_#f0f9ff,0_0_0_36px_#f8fafc]" />
+                <div className="relative">
+                    <div className="font-mono text-[8.5pt] font-semibold tracking-[0.14em] text-sky-700">{record.serial} · COMPLETED {record.year}</div>
+                    <h1 className="mt-1 text-[25pt] font-semibold leading-none tracking-tight">{record.name}</h1>
+                    <p className="mt-3 max-w-[6.3in] text-[9.5pt] leading-relaxed text-slate-600">{record.theme}</p>
+                </div>
+            </section>
+
+            <section className="instrument-case-card-spec min-h-0 flex-1">{children}</section>
+
+            <section className="mt-4 grid grid-cols-[0.85in_1fr] gap-3 border-t border-slate-300 pt-3 text-[8.5pt] leading-relaxed">
+                <span className="font-mono text-[7.5pt] font-semibold uppercase tracking-wider text-slate-500">Origin</span>
+                <span>{record.origin}</span>
+            </section>
+
+            <footer className="mt-4 flex items-end justify-between gap-4 border-t border-slate-300 pt-4">
+                <div className="space-y-2 text-slate-600">
+                    <p className="font-mono text-[7.5pt] tracking-wide">{url}</p>
+                    <a href={siteConfig.links.discord} className="inline-flex items-center gap-1.5 text-[8.5pt] font-semibold text-slate-800 underline decoration-sky-500 underline-offset-2">
+                        <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                        Questions? Join the K7RHY Discord
+                    </a>
+                </div>
+                <div className="rounded-md border border-slate-300 bg-white p-1.5">
+                    <QRCodeSVG value={url} size={82} level="M" marginSize={1} title={`Open the record for ${record.serial}`} />
+                </div>
+            </footer>
+        </article>
+    );
+}

--- a/components/instrument/instrument-mdx-components.tsx
+++ b/components/instrument/instrument-mdx-components.tsx
@@ -1,0 +1,3 @@
+import baseComponents from '@/components/mdx-components';
+
+export const instrumentMdxComponents = baseComponents;

--- a/components/instrument/instrument-record-page.test.tsx
+++ b/components/instrument/instrument-record-page.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { InstrumentRecordPage } from './instrument-record-page';
+import type { InstrumentRecord } from '@/types/instrument';
+
+vi.mock('next/image', () => ({
+    default: ({ fill: _fill, priority: _priority, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean; priority?: boolean }) => React.createElement('img', props),
+}));
+
+const record: InstrumentRecord = {
+    serial: 'RLY26001',
+    modelCode: 'RLY',
+    modelDescription: 'Relay',
+    year: 2026,
+    index: 1,
+    publish: true,
+    name: 'Relay Lipstick',
+    completed: '2026-06-19',
+    origin: 'Designed, built, and voiced by K7RHY Resonance Lab.',
+    theme: 'Articulate and touch-sensitive.',
+    images: [{ src: '/images/instruments/RLY26001/front.jpg', alt: 'RLY26001 front view' }],
+    related: { label: 'Explore the Relay Guitar family', href: '/relay' },
+    content: '',
+};
+
+describe('InstrumentRecordPage', () => {
+    it('leads with identity, photograph, theme, and print action', () => {
+        render(
+            <InstrumentRecordPage record={record}>
+                <div>Structured specification</div>
+            </InstrumentRecordPage>,
+        );
+
+        expect(screen.getByRole('heading', { level: 1, name: 'Relay Lipstick' })).toBeInTheDocument();
+        expect(screen.getAllByText('RLY26001')).toHaveLength(2);
+        expect(screen.getByText('Articulate and touch-sensitive.')).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: 'RLY26001 front view' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /print case card/i })).toHaveAttribute('href', '/sn/RLY26001/print');
+        expect(screen.getByText('Structured specification')).toBeInTheDocument();
+    });
+
+    it('renders the optional discovery link without replacing site navigation', () => {
+        render(
+            <InstrumentRecordPage record={record}>
+                <div>Structured specification</div>
+            </InstrumentRecordPage>,
+        );
+
+        expect(screen.getByRole('link', { name: 'Explore the Relay Guitar family' })).toHaveAttribute('href', '/relay');
+    });
+});

--- a/components/instrument/instrument-record-page.tsx
+++ b/components/instrument/instrument-record-page.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowRight, FileText, Guitar, Printer } from 'lucide-react';
+import type { InstrumentRecord } from '@/types/instrument';
+
+export interface InstrumentRecordPageProps {
+    record: InstrumentRecord;
+    children: React.ReactNode;
+}
+
+function formatCompletedDate(completed: string) {
+    return new Date(`${completed}T00:00:00Z`).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'UTC',
+    });
+}
+
+export function InstrumentRecordPage({ record, children }: InstrumentRecordPageProps) {
+    const primaryImage = record.images[0];
+
+    return (
+        <main className="container mx-auto max-w-6xl space-y-8 px-4 py-8 md:px-8 md:py-12">
+            <section className="relative isolate overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-sky-50 via-white to-emerald-50 shadow-lg ring-1 ring-black/5 dark:border-slate-800 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900 dark:ring-white/10">
+                <div className="absolute -left-20 bottom-0 -z-10 h-64 w-64 rounded-full bg-emerald-300/25 blur-3xl dark:bg-emerald-500/10" />
+                <div className="absolute -right-20 top-0 -z-10 h-64 w-64 rounded-full bg-sky-300/30 blur-3xl dark:bg-sky-500/10" />
+                <div className="grid lg:grid-cols-[1.08fr_0.92fr]">
+                    <div className="flex flex-col justify-center space-y-5 p-7 md:p-10 lg:p-12">
+                        <div className="flex flex-wrap items-center gap-3">
+                            <span className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/80 px-3 py-1.5 font-mono text-xs font-semibold uppercase tracking-[0.16em] text-slate-700 backdrop-blur dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-300">
+                                <Guitar className="h-3.5 w-3.5" aria-hidden="true" />
+                                Individual instrument
+                            </span>
+                            <span className="font-mono text-sm font-semibold tracking-[0.16em] text-sky-700 dark:text-sky-300">{record.serial}</span>
+                        </div>
+                        <div>
+                            <p className="mb-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{record.modelDescription} · completed {record.year}</p>
+                            <h1 className="text-4xl font-semibold tracking-tight text-slate-950 dark:text-slate-50 sm:text-5xl">{record.name}</h1>
+                        </div>
+                        <p className="max-w-2xl text-lg leading-relaxed text-slate-700 dark:text-slate-300">{record.theme}</p>
+                        <dl className="grid gap-4 border-t border-slate-300/70 pt-5 text-sm dark:border-slate-700/70 sm:grid-cols-2">
+                            <div>
+                                <dt className="font-mono text-xs font-semibold uppercase tracking-wider text-muted-foreground">Origin</dt>
+                                <dd className="mt-1 leading-relaxed text-slate-800 dark:text-slate-200">{record.origin}</dd>
+                            </div>
+                            <div>
+                                <dt className="font-mono text-xs font-semibold uppercase tracking-wider text-muted-foreground">Completed</dt>
+                                <dd className="mt-1 text-slate-800 dark:text-slate-200">{formatCompletedDate(record.completed)}</dd>
+                            </div>
+                        </dl>
+                        <div>
+                            <Link href={`/sn/${record.serial}/print`} className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-900 shadow-sm transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800">
+                                <Printer className="h-4 w-4" aria-hidden="true" />
+                                Print case card
+                            </Link>
+                        </div>
+                    </div>
+                    <div className="relative min-h-80 overflow-hidden border-t border-border/60 bg-slate-100 dark:bg-slate-900 lg:min-h-[36rem] lg:border-l lg:border-t-0">
+                        <Image src={primaryImage.src} alt={primaryImage.alt} fill priority className="object-cover" sizes="(min-width: 1024px) 42vw, 100vw" />
+                        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-slate-950/45 to-transparent" />
+                        <div className="absolute bottom-4 right-4 rounded-md border border-white/30 bg-slate-950/60 px-3 py-1.5 font-mono text-xs tracking-[0.14em] text-white backdrop-blur">{record.serial}</div>
+                    </div>
+                </div>
+            </section>
+
+            <article className="space-y-8" aria-label={`${record.name} instrument details`}>
+                {children}
+            </article>
+
+            {record.related && (
+                <aside className="flex flex-col gap-5 rounded-2xl border border-sky-200 bg-gradient-to-r from-sky-50 to-emerald-50 p-6 dark:border-sky-900/70 dark:from-sky-950/30 dark:to-emerald-950/20 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex gap-4">
+                        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-sky-200 bg-white text-sky-700 shadow-sm dark:border-sky-900 dark:bg-slate-950 dark:text-sky-300">
+                            <FileText className="h-5 w-5" aria-hidden="true" />
+                        </span>
+                        <div>
+                            <h2 className="font-semibold">Continue exploring</h2>
+                            <p className="mt-1 text-sm text-muted-foreground">See how this instrument fits into the wider K7RHY work.</p>
+                        </div>
+                    </div>
+                    <Link href={record.related.href} className="inline-flex items-center gap-2 font-semibold text-sky-800 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:text-sky-300">
+                        {record.related.label}
+                        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </Link>
+                </aside>
+            )}
+        </main>
+    );
+}

--- a/components/instrument/instrument-spec.test.tsx
+++ b/components/instrument/instrument-spec.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ControlLayout, InstrumentSpec, Pickup, PickupConfiguration, Pot, PotPosition, Selector, SelectorPosition } from './instrument-spec';
+
+const pickups = (
+    <PickupConfiguration>
+        <Pickup position="bridge" type="humbucker" brand="GFS" model="VEH" />
+    </PickupConfiguration>
+);
+
+describe('instrument MDX components', () => {
+    it('numbers selector children from their sequence', () => {
+        render(
+            <Selector label="Pickup selector" positions={3}>
+                <SelectorPosition voice="Bridge">Attack</SelectorPosition>
+                <SelectorPosition voice="Both">Balance</SelectorPosition>
+                <SelectorPosition voice="Neck">Warmth</SelectorPosition>
+            </Selector>,
+        );
+
+        expect(screen.getByText('1')).toBeInTheDocument();
+        expect(screen.getByText('2')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('rejects a selector whose child count does not match', () => {
+        expect(() =>
+            render(
+                <Selector label="Pickup selector" positions={3}>
+                    <SelectorPosition voice="Bridge">Attack</SelectorPosition>
+                    <SelectorPosition voice="Neck">Warmth</SelectorPosition>
+                </Selector>,
+            ),
+        ).toThrow('Pickup selector declares 3 positions but contains 2');
+    });
+
+    it('rejects switched pots without down and up states', () => {
+        expect(() =>
+            render(
+                <Pot label="Volume" mechanism="push-pull">
+                    <PotPosition position="down" voice="Core">Output</PotPosition>
+                </Pot>,
+            ),
+        ).toThrow('Volume push-pull requires exactly one down and one up position');
+    });
+
+    it('rejects a standard pot without one normal state', () => {
+        expect(() =>
+            render(
+                <Pot label="Volume" mechanism="standard">
+                    <PotPosition position="down" voice="Core">Output</PotPosition>
+                </Pot>,
+            ),
+        ).toThrow('Volume standard requires exactly one normal position');
+    });
+
+    it('rejects a spec missing a control layout', () => {
+        expect(() => render(<InstrumentSpec>{pickups}</InstrumentSpec>)).toThrow('InstrumentSpec requires exactly one PickupConfiguration and one ControlLayout');
+    });
+
+    it('renders valid pickup, selector, and push-push content', () => {
+        render(
+            <InstrumentSpec>
+                {pickups}
+                <ControlLayout>
+                    <Selector label="Selector" positions={3}>
+                        <SelectorPosition voice="Bridge">Attack</SelectorPosition>
+                        <SelectorPosition voice="Both">Balance</SelectorPosition>
+                        <SelectorPosition voice="Neck">Warmth</SelectorPosition>
+                    </Selector>
+                    <Pot label="Tone" mechanism="push-push">
+                        <PotPosition position="down" voice="Open">Standard rolloff</PotPosition>
+                        <PotPosition position="up" voice="Focused">Tighter response</PotPosition>
+                    </Pot>
+                </ControlLayout>
+            </InstrumentSpec>,
+        );
+
+        expect(screen.getByText('GFS VEH')).toBeInTheDocument();
+        expect(screen.getByText('Focused')).toBeInTheDocument();
+    });
+});

--- a/components/instrument/instrument-spec.tsx
+++ b/components/instrument/instrument-spec.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { SlidersHorizontal, Sparkles } from 'lucide-react';
+
+type SelectorCount = 3 | 5;
+type PotMechanism = 'standard' | 'push-pull' | 'push-push';
+type PotState = 'normal' | 'down' | 'up';
+
+export interface SelectorPositionProps {
+    voice: string;
+    children: React.ReactNode;
+    index?: number;
+}
+
+export interface PotPositionProps {
+    position: PotState;
+    voice: string;
+    children: React.ReactNode;
+}
+
+export interface PickupProps {
+    position: string;
+    type: string;
+    brand: string;
+    model: string;
+    children?: React.ReactNode;
+}
+
+function isEmptyChild(child: React.ReactNode): boolean {
+    return child === null || child === undefined || (typeof child === 'string' && child.trim() === '');
+}
+
+function elementChildren<P>(children: React.ReactNode, type: React.ComponentType<P>, parent: string): React.ReactElement<P>[] {
+    const result: React.ReactElement<P>[] = [];
+
+    React.Children.forEach(children, (child) => {
+        if (isEmptyChild(child)) return;
+        if (!React.isValidElement<P>(child) || child.type !== type) {
+            throw new Error(`${parent} contains an unsupported child`);
+        }
+        result.push(child);
+    });
+
+    return result;
+}
+
+function requireText(value: string, field: string, parent: string) {
+    if (value.trim().length === 0) {
+        throw new Error(`${parent} requires ${field}`);
+    }
+}
+
+export function InstrumentSpec({ children }: { children: React.ReactNode }) {
+    const pickups: React.ReactElement[] = [];
+    const controls: React.ReactElement[] = [];
+
+    React.Children.forEach(children, (child) => {
+        if (isEmptyChild(child)) return;
+        if (!React.isValidElement(child)) throw new Error('InstrumentSpec contains an unsupported child');
+        if (child.type === PickupConfiguration) pickups.push(child);
+        else if (child.type === ControlLayout) controls.push(child);
+        else throw new Error('InstrumentSpec contains an unsupported child');
+    });
+
+    if (pickups.length !== 1 || controls.length !== 1) {
+        throw new Error('InstrumentSpec requires exactly one PickupConfiguration and one ControlLayout');
+    }
+
+    return (
+        <section data-instrument-spec className="space-y-6">
+            {controls[0]}
+            {pickups[0]}
+        </section>
+    );
+}
+
+export function PickupConfiguration({ children }: { children: React.ReactNode }) {
+    const pickups = elementChildren(children, Pickup, 'PickupConfiguration');
+    if (pickups.length === 0) throw new Error('PickupConfiguration requires at least one Pickup');
+
+    return (
+        <section data-pickup-configuration className="rounded-2xl border border-border/70 bg-card p-5 shadow-sm md:p-6">
+            <div className="mb-5 flex items-center gap-3">
+                <span className="grid h-10 w-10 place-items-center rounded-xl bg-gradient-to-br from-sky-500 to-indigo-600 text-white shadow-sm">
+                    <Sparkles className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <div>
+                    <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-sky-700 dark:text-sky-300">Magnetic voice</p>
+                    <h2 className="text-xl font-semibold tracking-tight">Pickup configuration</h2>
+                </div>
+            </div>
+            <div className="grid gap-3 md:grid-cols-3">{pickups}</div>
+        </section>
+    );
+}
+
+export function Pickup({ position, type, brand, model, children }: PickupProps) {
+    requireText(position, 'position', 'Pickup');
+    requireText(type, 'type', `Pickup ${position}`);
+    requireText(brand, 'brand', `Pickup ${position}`);
+    requireText(model, 'model', `Pickup ${position}`);
+    const details = elementChildren(children, PickupDetail, `Pickup ${position}`);
+
+    return (
+        <article className="rounded-xl border border-border/60 bg-muted/25 p-4">
+            <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted-foreground">{position}</p>
+            <h3 className="mt-1 text-base font-semibold">{brand} {model}</h3>
+            <p className="mt-1 text-sm capitalize text-muted-foreground">{type.replaceAll('-', ' ')}</p>
+            {details.length > 0 && <dl className="mt-3 space-y-2 border-t border-border/60 pt-3 text-sm">{details}</dl>}
+        </article>
+    );
+}
+
+export function PickupDetail({ label, children }: { label: string; children: React.ReactNode }) {
+    requireText(label, 'label', 'PickupDetail');
+    return (
+        <div className="flex items-baseline justify-between gap-3">
+            <dt className="text-muted-foreground">{label}</dt>
+            <dd className="text-right font-medium">{children}</dd>
+        </div>
+    );
+}
+
+export function ControlLayout({ children }: { children: React.ReactNode }) {
+    const controls: React.ReactElement[] = [];
+
+    React.Children.forEach(children, (child) => {
+        if (isEmptyChild(child)) return;
+        if (!React.isValidElement(child) || (child.type !== Selector && child.type !== Pot)) {
+            throw new Error('ControlLayout contains an unsupported child');
+        }
+        controls.push(child);
+    });
+
+    if (controls.length === 0) throw new Error('ControlLayout requires at least one Selector or Pot');
+
+    return (
+        <section data-control-layout className="rounded-2xl border border-border/70 bg-card p-5 shadow-sm md:p-6">
+            <div className="mb-5 flex items-center gap-3">
+                <span className="grid h-10 w-10 place-items-center rounded-xl bg-gradient-to-br from-sky-500 to-indigo-600 text-white shadow-sm">
+                    <SlidersHorizontal className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <div>
+                    <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-sky-700 dark:text-sky-300">Find its voices</p>
+                    <h2 className="text-xl font-semibold tracking-tight">Voice and control map</h2>
+                </div>
+            </div>
+            <div className="space-y-4">{controls}</div>
+        </section>
+    );
+}
+
+export function Selector({ label, positions, children }: { label: string; positions: SelectorCount; children: React.ReactNode }) {
+    requireText(label, 'label', 'Selector');
+    const items = elementChildren(children, SelectorPosition, label);
+    if (items.length !== positions) {
+        throw new Error(`${label} declares ${positions} positions but contains ${items.length}`);
+    }
+
+    return (
+        <article className="rounded-xl border border-border/60 p-4">
+            <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+                <h3 className="font-semibold">{label}</h3>
+                <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">{positions}-way selector</span>
+            </div>
+            <ol className={positions === 5 ? 'grid gap-2 sm:grid-cols-5' : 'grid gap-2 sm:grid-cols-3'}>{items.map((item, index) => React.cloneElement(item, { index: index + 1, key: `${label}-${index}` } as SelectorPositionProps & React.Attributes))}</ol>
+        </article>
+    );
+}
+
+export function SelectorPosition({ voice, children, index }: SelectorPositionProps) {
+    requireText(voice, 'voice', 'SelectorPosition');
+    if (!index) throw new Error('SelectorPosition must be rendered inside Selector');
+
+    return (
+        <li className="rounded-lg border border-border/60 bg-muted/25 p-3">
+            <div className="mb-2 grid h-7 w-7 place-items-center rounded-full bg-slate-900 font-mono text-xs font-bold text-white dark:bg-slate-100 dark:text-slate-950">{index}</div>
+            <p className="text-sm font-semibold">{voice}</p>
+            <div className="mt-1 text-sm leading-relaxed text-muted-foreground">{children}</div>
+        </li>
+    );
+}
+
+export function Pot({ label, mechanism, children }: { label: string; mechanism: PotMechanism; children: React.ReactNode }) {
+    requireText(label, 'label', 'Pot');
+    const items = elementChildren(children, PotPosition, label);
+    const states = items.map((item) => item.props.position);
+    const valid = mechanism === 'standard' ? states.length === 1 && states[0] === 'normal' : states.length === 2 && states.filter((state) => state === 'down').length === 1 && states.filter((state) => state === 'up').length === 1;
+
+    if (!valid) {
+        throw new Error(mechanism === 'standard' ? `${label} standard requires exactly one normal position` : `${label} ${mechanism} requires exactly one down and one up position`);
+    }
+
+    return (
+        <article className="rounded-xl border border-border/60 p-4">
+            <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+                <h3 className="font-semibold">{label}</h3>
+                <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">{mechanism.replace('-', ' ')}</span>
+            </div>
+            <div className={items.length === 1 ? 'grid gap-2' : 'grid gap-2 sm:grid-cols-2'}>{items}</div>
+        </article>
+    );
+}
+
+export function PotPosition({ position, voice, children }: PotPositionProps) {
+    requireText(voice, 'voice', `PotPosition ${position}`);
+    return (
+        <div className="rounded-lg border border-border/60 bg-muted/25 p-3">
+            <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-sky-700 dark:text-sky-300">{position}</p>
+            <p className="mt-1 text-sm font-semibold">{voice}</p>
+            <div className="mt-1 text-sm leading-relaxed text-muted-foreground">{children}</div>
+        </div>
+    );
+}
+
+InstrumentSpec.displayName = 'InstrumentSpec';
+PickupConfiguration.displayName = 'PickupConfiguration';
+Pickup.displayName = 'Pickup';
+PickupDetail.displayName = 'PickupDetail';
+ControlLayout.displayName = 'ControlLayout';
+Selector.displayName = 'Selector';
+SelectorPosition.displayName = 'SelectorPosition';
+Pot.displayName = 'Pot';
+PotPosition.displayName = 'PotPosition';

--- a/components/instrument/print-case-card-controls.test.tsx
+++ b/components/instrument/print-case-card-controls.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { PrintCaseCardControls } from './print-case-card-controls';
+
+describe('PrintCaseCardControls', () => {
+    it('invokes print on mount and provides a working fallback button', () => {
+        const print = vi.spyOn(window, 'print').mockImplementation(() => undefined);
+        render(<PrintCaseCardControls />);
+
+        expect(print).toHaveBeenCalledOnce();
+        fireEvent.click(screen.getByRole('button', { name: 'Print case card' }));
+        expect(print).toHaveBeenCalledTimes(2);
+    });
+});

--- a/components/instrument/print-case-card-controls.tsx
+++ b/components/instrument/print-case-card-controls.tsx
@@ -9,7 +9,7 @@ export function PrintCaseCardControls() {
     }, []);
 
     return (
-        <div className="instrument-print-controls mx-auto flex max-w-[7.8in] items-center justify-between gap-4 px-4 pt-6 print:hidden">
+        <div className="instrument-print-controls mx-auto flex max-w-[7.57in] items-center justify-between gap-4 px-4 pt-6 print:hidden">
             <p className="text-sm text-muted-foreground">The card is formatted for one portrait Letter or A4 page.</p>
             <button type="button" onClick={() => window.print()} className="inline-flex shrink-0 items-center gap-2 rounded-lg border bg-background px-4 py-2 text-sm font-semibold shadow-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500">
                 <Printer className="h-4 w-4" aria-hidden="true" />

--- a/components/instrument/print-case-card-controls.tsx
+++ b/components/instrument/print-case-card-controls.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { Printer } from 'lucide-react';
+
+export function PrintCaseCardControls() {
+    useEffect(() => {
+        window.print();
+    }, []);
+
+    return (
+        <div className="instrument-print-controls mx-auto flex max-w-[7.8in] items-center justify-between gap-4 px-4 pt-6 print:hidden">
+            <p className="text-sm text-muted-foreground">The card is formatted for one portrait Letter or A4 page.</p>
+            <button type="button" onClick={() => window.print()} className="inline-flex shrink-0 items-center gap-2 rounded-lg border bg-background px-4 py-2 text-sm font-semibold shadow-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500">
+                <Printer className="h-4 w-4" aria-hidden="true" />
+                Print case card
+            </button>
+        </div>
+    );
+}

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -46,6 +46,7 @@ import { RelayVoicingSection } from '@/components/relay/relay-voicing-overview';
 import { RelayHero } from '@/components/relay/relay-hero';
 import { RelayProcessOverview } from '@/components/relay/relay-process-overview';
 import { DocTerm } from '@/components/doc/doc-term';
+import { ControlLayout, InstrumentSpec, Pickup, PickupConfiguration, PickupDetail, Pot, PotPosition, Selector, SelectorPosition } from '@/components/instrument/instrument-spec';
 
 //import { Style } from "@/registry/styles"
 
@@ -186,6 +187,15 @@ const components: MDXComponents = {
     RelayVoicingSection,
     RelayHero,
     RelayProcessOverview,
+    InstrumentSpec,
+    PickupConfiguration,
+    Pickup,
+    PickupDetail,
+    ControlLayout,
+    Selector,
+    SelectorPosition,
+    Pot,
+    PotPosition,
 };
 
 // interface MdxProps {

--- a/components/navigation/site-footer.tsx
+++ b/components/navigation/site-footer.tsx
@@ -25,7 +25,7 @@ export function SiteFooter() {
     const copyrightYear = currentYear > 2024 ? `2024–${currentYear}` : '2024';
 
     return (
-        <footer className="border-t border-border/60 bg-muted/30">
+        <footer data-site-footer className="border-t border-border/60 bg-muted/30">
             <div className="container mx-auto px-4 py-10 md:px-8">
                 <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
                     {/* Brand */}

--- a/components/navigation/site-header.tsx
+++ b/components/navigation/site-header.tsx
@@ -7,7 +7,7 @@ import ViewportDebugLabel from '@/components/viewport-debug-label';
 
 export function SiteHeader() {
     return (
-        <header className="sticky top-0 z-50 w-full border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <header data-site-header className="sticky top-0 z-50 w-full border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="container flex h-14 max-w-screen-2xl items-center">
                 <MainNav />
                 <MobileNav />

--- a/config/instrument-model-codes.ts
+++ b/config/instrument-model-codes.ts
@@ -1,0 +1,9 @@
+export const INSTRUMENT_MODEL_CODES: Readonly<Record<string, string>> = {
+    RLY: 'Relay',
+    FND: 'Fender',
+    GIB: 'Gibson',
+    PRS: 'PRS',
+    TEL: 'Telecaster-style',
+    STR: 'Stratocaster-style',
+    LES: 'Les Paul-style',
+};

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import axios from 'axios';
 import { z } from 'zod';
 import crypto from 'crypto';
+import { validateInstrumentDocument } from './lib/instruments/validation';
 
 const blogSchema = z.object({
     title: z.string(),
@@ -15,6 +16,27 @@ const blogSchema = z.object({
     readingTime: z.number().optional().default(0),
     isAISummary: z.boolean().optional().default(false), // Track AI-generated summaries
     content: z.string(), // Explicit content property for markdown content
+});
+
+const instrumentSchema = z.object({
+    publish: z.boolean().optional().default(false),
+    name: z.string().min(1),
+    completed: z.string().date('Invalid completion date.'),
+    origin: z.string().min(1),
+    theme: z.string().min(1),
+    images: z.array(
+        z.object({
+            src: z.string().min(1),
+            alt: z.string().min(1),
+        }),
+    ),
+    related: z
+        .object({
+            label: z.string().min(1),
+            href: z.string().startsWith('/'),
+        })
+        .optional(),
+    content: z.string(),
 });
 
 const CACHE_DIR = join(process.cwd(), '.content-collections', 'cache');
@@ -222,6 +244,14 @@ ${finalContent}`;
     },
 });
 
+const instruments = defineCollection({
+    name: 'instruments',
+    directory: 'content/instruments',
+    include: '**/*.mdx',
+    schema: instrumentSchema,
+    transform: async (data) => ({ ...data, ...validateInstrumentDocument(data._meta.path, data) }),
+});
+
 export default defineConfig({
-    collections: [blog],
+    collections: [blog, instruments],
 });

--- a/content/instruments/README.md
+++ b/content/instruments/README.md
@@ -1,0 +1,12 @@
+# Serialized instrument authoring
+
+1. Add or edit the three-letter description in `config/instrument-model-codes.ts`.
+2. Copy `RLY26001.mdx` to the new uppercase `MMMYYNNN.mdx` filename.
+3. Keep `publish: false` while replacing every identity field, image, pickup, selector, and pot state.
+4. Put exact-instrument photographs under `public/images/instruments/<SERIAL>/` and give each useful alt text.
+5. Run `npx vitest run` and `npm run build`.
+6. Preview `/sn/<SERIAL>` in light, dark, desktop, and mobile layouts.
+7. Preview `/sn/<SERIAL>/print` on Letter and A4 and scan its QR code.
+8. Set `publish: true`, rerun `npm run build`, and deploy.
+
+Selector children are numbered from their order. Three-way selectors require three children; five-way selectors require five. Standard pots require one `normal` position. Push-pull and push-push pots require one `down` and one `up` position.

--- a/content/instruments/RLY26001.mdx
+++ b/content/instruments/RLY26001.mdx
@@ -1,0 +1,43 @@
+---
+publish: false
+name: 'Relay Lipstick'
+completed: '2026-06-19'
+origin: 'Designed, built, and voiced by K7RHY Resonance Lab.'
+theme: 'An articulate, touch-sensitive instrument with a familiar core and one carefully shaped alternate identity.'
+images:
+    - src: '/images/products/guitars/rainbow-tele/front.jpeg'
+      alt: 'Example instrument photograph used while developing the serialized record template'
+related:
+    label: 'Explore the Relay Guitar family'
+    href: '/relay'
+---
+
+<InstrumentSpec>
+    <PickupConfiguration>
+        <Pickup position="bridge" type="humbucker" brand="GFS" model="VEH">
+            <PickupDetail label="Magnet">Alnico V</PickupDetail>
+        </Pickup>
+        <Pickup position="middle" type="lipstick" brand="GFS" model="Pro-Tube" />
+        <Pickup position="neck" type="humbucker" brand="GFS" model="Professional Alnico II" />
+    </PickupConfiguration>
+
+    <ControlLayout>
+        <Selector label="Pickup selector" positions={3}>
+            <SelectorPosition voice="Bridge">Authority and attack</SelectorPosition>
+            <SelectorPosition voice="Bridge + Neck">Width and balance</SelectorPosition>
+            <SelectorPosition voice="Neck">Warmth and detail</SelectorPosition>
+        </Selector>
+        <Pot label="Master volume" mechanism="push-pull">
+            <PotPosition position="down" voice="Core voice">Controls overall output.</PotPosition>
+            <PotPosition position="up" voice="Lipstick Voice">Adds the middle lipstick and reshapes the bridge response.</PotPosition>
+        </Pot>
+        <Pot label="Master tone" mechanism="push-push">
+            <PotPosition position="down" voice="Open contour">Standard treble rolloff.</PotPosition>
+            <PotPosition position="up" voice="Focused contour">Tightens and focuses the response.</PotPosition>
+        </Pot>
+    </ControlLayout>
+</InstrumentSpec>
+
+## This instrument
+
+This unpublished example establishes the authoring shape for future serialized instruments. Replace the photograph and copy before using it as a real owner record.

--- a/content/instruments/RLY26001.mdx
+++ b/content/instruments/RLY26001.mdx
@@ -1,12 +1,12 @@
 ---
-publish: false
+publish: true
 name: 'Relay Lipstick'
 completed: '2026-06-19'
-origin: 'Designed, built, and voiced by K7RHY Resonance Lab.'
-theme: 'An articulate, touch-sensitive instrument with a familiar core and one carefully shaped alternate identity.'
+origin: 'Designed, assembled, and individually voiced by K7RHY Resonance Lab as a demonstration Relay build.'
+theme: 'A wide-range Tele-style instrument that moves from authoritative humbucker drive to glassy, dimensional textures without losing its direct, familiar feel.'
 images:
     - src: '/images/products/guitars/rainbow-tele/front.jpeg'
-      alt: 'Example instrument photograph used while developing the serialized record template'
+      alt: 'Front view of the rainbow-finished Relay Lipstick demonstration guitar'
 related:
     label: 'Explore the Relay Guitar family'
     href: '/relay'
@@ -18,26 +18,32 @@ related:
             <PickupDetail label="Magnet">Alnico V</PickupDetail>
         </Pickup>
         <Pickup position="middle" type="lipstick" brand="GFS" model="Pro-Tube" />
-        <Pickup position="neck" type="humbucker" brand="GFS" model="Professional Alnico II" />
+        <Pickup position="neck" type="humbucker" brand="GFS" model="Professional Alnico II">
+            <PickupDetail label="Magnet">Alnico II</PickupDetail>
+        </Pickup>
     </PickupConfiguration>
 
     <ControlLayout>
         <Selector label="Pickup selector" positions={3}>
-            <SelectorPosition voice="Bridge">Authority and attack</SelectorPosition>
-            <SelectorPosition voice="Bridge + Neck">Width and balance</SelectorPosition>
-            <SelectorPosition voice="Neck">Warmth and detail</SelectorPosition>
+            <SelectorPosition voice="Bridge">Tight attack and firm low end for driven rhythm and focused leads.</SelectorPosition>
+            <SelectorPosition voice="Bridge + Neck">Broad, balanced, and open for clean or edge-of-breakup work.</SelectorPosition>
+            <SelectorPosition voice="Neck">Round and vocal for warm rhythm and fluid lead lines.</SelectorPosition>
         </Selector>
         <Pot label="Master volume" mechanism="push-pull">
-            <PotPosition position="down" voice="Core voice">Controls overall output.</PotPosition>
-            <PotPosition position="up" voice="Lipstick Voice">Adds the middle lipstick and reshapes the bridge response.</PotPosition>
+            <PotPosition position="down" voice="Core voices">Three-way control of the bridge and neck humbuckers.</PotPosition>
+            <PotPosition position="up" voice="Lipstick layer">Adds the middle pickup for extra chime, air, and texture.</PotPosition>
         </Pot>
         <Pot label="Master tone" mechanism="push-push">
-            <PotPosition position="down" voice="Open contour">Standard treble rolloff.</PotPosition>
-            <PotPosition position="up" voice="Focused contour">Tightens and focuses the response.</PotPosition>
+            <PotPosition position="down" voice="Open contour">Full response with conventional treble rolloff.</PotPosition>
+            <PotPosition position="up" voice="Focused contour">A tighter, more forward voice for a dense mix.</PotPosition>
         </Pot>
     </ControlLayout>
 </InstrumentSpec>
 
 ## This instrument
 
-This unpublished example establishes the authoring shape for future serialized instruments. Replace the photograph and copy before using it as a real owner record.
+Relay Lipstick is the demonstration instrument for the K7RHY serialized-record system. Its core is intentionally straightforward: two complementary humbuckers, a familiar three-way selector, and conventional master volume and tone controls. The two switching functions extend that foundation rather than replacing it.
+
+Pull the volume control to bring the middle lipstick pickup into any selector position. The added pickup opens the top end and introduces a more dimensional, percussive character—especially useful for clean arpeggios, layered rhythm parts, and touch-sensitive edge-of-breakup sounds. Press the tone control to engage the focused contour whenever the instrument needs a more compact footprint or a stronger midrange presence.
+
+The result is a guitar that can stay simple on stage and become surprisingly expansive when a song asks for another color.

--- a/docs/superpowers/plans/2026-06-19-instrument-records.md
+++ b/docs/superpowers/plans/2026-06-19-instrument-records.md
@@ -208,7 +208,7 @@ Run: `npx vitest run lib/instruments/serial.test.ts`
 
 Expected: PASS, 8 tests.
 
-- [ ] **Step 6: Commit the serial foundation**
+- [x] **Step 6: Commit the serial foundation**
 
 ```bash
 git add config/instrument-model-codes.ts types/instrument.ts lib/instruments/serial.ts lib/instruments/serial.test.ts
@@ -229,11 +229,11 @@ git commit -m "feat(instruments): add serial number model"
 
 **Interfaces:**
 - Consumes: `parseInstrumentSerial()` and `InstrumentFrontmatter` from Task 1.
-- Produces: `validateInstrumentDocument(path: string, data: InstrumentFrontmatter): InstrumentRecord` from a pure module with no generated-content import.
+- Produces: `validateInstrumentDocument(path: string, data: InstrumentFrontmatter): InstrumentSerial` from a pure module with no generated-content import; the collection transform combines these derived primitives with its schema-inferred data.
 - Produces: generated `allInstruments` and `Instrument` type from `content-collections`.
 - Produces: `getInstrument(serial: string)` and `getInstrumentStaticParams()`.
 
-- [ ] **Step 1: Write failing document-validation tests**
+- [x] **Step 1: Write failing document-validation tests**
 
 ```ts
 import { describe, expect, it } from 'vitest';
@@ -274,13 +274,13 @@ describe('validateInstrumentDocument', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and verify it fails**
+- [x] **Step 2: Run the test and verify it fails**
 
 Run: `npx vitest run lib/instruments/validation.test.ts`
 
 Expected: FAIL because `validation.ts` does not exist.
 
-- [ ] **Step 3: Implement pure document validation**
+- [x] **Step 3: Implement pure document validation**
 
 ```ts
 // lib/instruments/validation.ts
@@ -315,7 +315,7 @@ export function validateInstrumentDocument(path: string, data: InstrumentFrontma
 }
 ```
 
-- [ ] **Step 4: Add the instrument schema and transform to Content Collections**
+- [x] **Step 4: Add the instrument schema and transform to Content Collections**
 
 Add these definitions after `blogSchema` in `content-collections.ts`:
 
@@ -352,7 +352,7 @@ const instruments = defineCollection({
     directory: 'content/instruments',
     include: '**/*.mdx',
     schema: instrumentSchema,
-    transform: async (data) => validateInstrumentDocument(data._meta.path, data),
+    transform: async (data) => ({ ...data, ...validateInstrumentDocument(data._meta.path, data) }),
 });
 ```
 
@@ -364,7 +364,7 @@ export default defineConfig({
 });
 ```
 
-- [ ] **Step 5: Add generated-record lookup outside the collection dependency graph**
+- [x] **Step 5: Add generated-record lookup outside the collection dependency graph**
 
 ```ts
 // lib/instruments/records.ts
@@ -386,7 +386,7 @@ export function isInstrumentPublished(record: InstrumentRecord): boolean {
 }
 ```
 
-- [ ] **Step 6: Add a complete unpublished MDX fixture/template**
+- [x] **Step 6: Add a complete unpublished MDX fixture/template**
 
 Create `content/instruments/RLY26001.mdx`:
 
@@ -436,7 +436,7 @@ related:
 This unpublished example establishes the authoring shape for future serialized instruments. Replace the photograph and copy before using it as a real owner record.
 ```
 
-- [ ] **Step 7: Add the authoring checklist**
+- [x] **Step 7: Add the authoring checklist**
 
 ```md
 # Serialized instrument authoring
@@ -445,7 +445,7 @@ This unpublished example establishes the authoring shape for future serialized i
 2. Copy `RLY26001.mdx` to the new uppercase `MMMYYNNN.mdx` filename.
 3. Keep `publish: false` while replacing every identity field, image, pickup, selector, and pot state.
 4. Put exact-instrument photographs under `public/images/instruments/<SERIAL>/` and give each useful alt text.
-5. Run `npx content-collections build` and `npx vitest run`.
+5. Run `npx vitest run` and `npm run build`.
 6. Preview `/sn/<SERIAL>` in light, dark, desktop, and mobile layouts.
 7. Preview `/sn/<SERIAL>/print` on Letter and A4 and scan its QR code.
 8. Set `publish: true`, rerun `npm run build`, and deploy.
@@ -453,9 +453,9 @@ This unpublished example establishes the authoring shape for future serialized i
 Selector children are numbered from their order. Three-way selectors require three children; five-way selectors require five. Standard pots require one `normal` position. Push-pull and push-push pots require one `down` and one `up` position.
 ```
 
-- [ ] **Step 8: Generate content and run validation tests**
+- [x] **Step 8: Generate content and run validation tests**
 
-Run: `npx content-collections build && npx vitest run lib/instruments/validation.test.ts lib/instruments/serial.test.ts`
+Run: `npx vitest run lib/instruments/validation.test.ts lib/instruments/serial.test.ts && npx next build`
 
 Expected: generated declarations include `Instrument` and `allInstruments`; all focused tests PASS.
 

--- a/docs/superpowers/plans/2026-06-19-instrument-records.md
+++ b/docs/superpowers/plans/2026-06-19-instrument-records.md
@@ -459,7 +459,7 @@ Run: `npx vitest run lib/instruments/validation.test.ts lib/instruments/serial.t
 
 Expected: generated declarations include `Instrument` and `allInstruments`; all focused tests PASS.
 
-- [ ] **Step 9: Commit the content pipeline**
+- [x] **Step 9: Commit the content pipeline**
 
 ```bash
 git add content-collections.ts content/instruments/RLY26001.mdx content/instruments/README.md lib/instruments/validation.ts lib/instruments/validation.test.ts lib/instruments/records.ts
@@ -481,7 +481,7 @@ git commit -m "feat(instruments): add validated MDX records"
 - Produces: `instrumentMdxComponents`, the mapping used by both routes.
 - Contract: invalid children throw serial-independent structural messages; route/build output provides the affected MDX path.
 
-- [ ] **Step 1: Write failing structural tests**
+- [x] **Step 1: Write failing structural tests**
 
 ```tsx
 import React from 'react';
@@ -558,13 +558,13 @@ describe('instrument MDX components', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and verify it fails**
+- [x] **Step 2: Run the test and verify it fails**
 
 Run: `npx vitest run components/instrument/instrument-spec.test.tsx`
 
 Expected: FAIL because `instrument-spec.tsx` does not exist.
 
-- [ ] **Step 3: Implement strict child collection and component contracts**
+- [x] **Step 3: Implement strict child collection and component contracts**
 
 Implement `components/instrument/instrument-spec.tsx` with these exact public prop types:
 
@@ -642,7 +642,7 @@ export function InstrumentSpec({ children }: { children: React.ReactNode }) {
 
 For `PickupConfiguration` and `ControlLayout`, call `elementChildren` with their single allowed child type and throw when their arrays are empty. `Pickup` concatenates `brand` and `model` in its heading and renders optional `PickupDetail` children in a `<dl>`. `SelectorPosition` renders its cloned `index` in a circular monospace marker plus `voice` and body copy. `PotPosition` renders its explicit state, voice, and body copy. Use semantic headings, ordered/unordered lists, and definition groups with `data-instrument-spec`, `data-control-layout`, and `data-pickup-configuration` attributes. Use Tailwind classes based on the approved slate/sky site language. Set `displayName` on every exported component for MDX/debug error clarity.
 
-- [ ] **Step 4: Register components for instrument MDX**
+- [x] **Step 4: Register components for instrument MDX**
 
 ```tsx
 // components/instrument/instrument-mdx-components.tsx
@@ -665,11 +665,11 @@ export const instrumentMdxComponents = {
 
 Also add the same named imports and mappings to `components/mdx-components.tsx` so instrument snippets remain recognized anywhere the shared MDX renderer is used.
 
-- [ ] **Step 5: Run focused component tests**
+- [x] **Step 5: Run focused component tests**
 
 Run: `npx vitest run components/instrument/instrument-spec.test.tsx`
 
-Expected: PASS, 5 tests.
+Expected: PASS, 6 tests.
 
 - [ ] **Step 6: Commit the strict MDX component system**
 

--- a/docs/superpowers/plans/2026-06-19-instrument-records.md
+++ b/docs/superpowers/plans/2026-06-19-instrument-records.md
@@ -65,7 +65,7 @@
 - Produces: `instrumentPath(serial: string): string`
 - Produces: `instrumentUrl(serial: string): string`
 
-- [ ] **Step 1: Write failing serial tests**
+- [x] **Step 1: Write failing serial tests**
 
 ```ts
 import { describe, expect, it } from 'vitest';
@@ -101,13 +101,13 @@ describe('instrument serials', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and verify it fails**
+- [x] **Step 2: Run the test and verify it fails**
 
 Run: `npx vitest run lib/instruments/serial.test.ts`
 
 Expected: FAIL because `./serial` does not exist.
 
-- [ ] **Step 3: Add the editable registry and shared types**
+- [x] **Step 3: Add the editable registry and shared types**
 
 ```ts
 // config/instrument-model-codes.ts
@@ -156,7 +156,7 @@ export interface InstrumentFrontmatter {
 export interface InstrumentRecord extends InstrumentFrontmatter, InstrumentSerial {}
 ```
 
-- [ ] **Step 4: Implement serial parsing and URL construction**
+- [x] **Step 4: Implement serial parsing and URL construction**
 
 ```ts
 // lib/instruments/serial.ts
@@ -202,7 +202,7 @@ export function instrumentUrl(serial: string): string {
 }
 ```
 
-- [ ] **Step 5: Run focused tests**
+- [x] **Step 5: Run focused tests**
 
 Run: `npx vitest run lib/instruments/serial.test.ts`
 

--- a/docs/superpowers/plans/2026-06-19-instrument-records.md
+++ b/docs/superpowers/plans/2026-06-19-instrument-records.md
@@ -824,7 +824,7 @@ Run: `npx vitest run components/instrument/instrument-record-page.test.tsx && np
 
 Expected: component tests PASS; build emits `/sn/[serial]` and the unpublished fixture does not produce a public production page.
 
-- [ ] **Step 6: Commit the public record page**
+- [x] **Step 6: Commit the public record page**
 
 ```bash
 git add components/instrument/instrument-record-page.tsx components/instrument/instrument-record-page.test.tsx app/sn/[serial]/page.tsx
@@ -852,13 +852,13 @@ git commit -m "feat(instruments): add serial record pages"
 - Produces: QR SVG value from `instrumentUrl(record.serial)`.
 - Produces: browser print invocation with visible fallback button.
 
-- [ ] **Step 1: Install the QR renderer**
+- [x] **Step 1: Install the QR renderer**
 
 Run: `npm install qrcode.react`
 
 Expected: `qrcode.react` appears in dependencies and the lockfile updates.
 
-- [ ] **Step 2: Write failing case-card tests**
+- [x] **Step 2: Write failing case-card tests**
 
 ```tsx
 import React from 'react';
@@ -893,7 +893,7 @@ describe('InstrumentCaseCard', () => {
 });
 ```
 
-- [ ] **Step 3: Write failing print-control test**
+- [x] **Step 3: Write failing print-control test**
 
 ```tsx
 import React from 'react';
@@ -912,7 +912,7 @@ describe('PrintCaseCardControls', () => {
 });
 ```
 
-- [ ] **Step 4: Implement the case-card wrapper**
+- [x] **Step 4: Implement the case-card wrapper**
 
 ```tsx
 // components/instrument/instrument-case-card.tsx
@@ -958,7 +958,7 @@ export function InstrumentCaseCard({ record, children }: { record: InstrumentRec
 
 Do not access or render `record.images` in this component.
 
-- [ ] **Step 5: Implement automatic print with fallback**
+- [x] **Step 5: Implement automatic print with fallback**
 
 ```tsx
 // components/instrument/print-case-card-controls.tsx
@@ -981,7 +981,7 @@ export function PrintCaseCardControls() {
 }
 ```
 
-- [ ] **Step 6: Add nested route styling and one-page print constraints**
+- [x] **Step 6: Add nested route styling and one-page print constraints**
 
 ```tsx
 // app/sn/layout.tsx
@@ -1049,7 +1049,7 @@ export default function InstrumentLayout({ children }: { children: React.ReactNo
 
 Keep text at or above 9pt in print. Use explicit grid row limits and line clamping for theme/origin only if the full supplied text would otherwise produce a second page; never clamp control instructions.
 
-- [ ] **Step 7: Implement the print route**
+- [x] **Step 7: Implement the print route**
 
 Create `app/sn/[serial]/print/page.tsx` with the same imports and `Props` type as the public route plus `InstrumentCaseCard` and `PrintCaseCardControls`. Use `resolveInstrumentRequest` from Task 6 when Task 6 is complete; until then use the same normalization, redirect, lookup, and publication conditions from Task 4. The component body is:
 
@@ -1066,7 +1066,7 @@ Create `app/sn/[serial]/print/page.tsx` with the same imports and `Props` type a
 
 Export `generateStaticParams()` by returning `getInstrumentStaticParams()`. Implement `generateMetadata()` with title `Case card · ${record.name} · ${serial} | K7RHY` and `robots: { index: false, follow: false }` so the canonical instrument record, not the utility print route, appears in search.
 
-- [ ] **Step 8: Run focused tests**
+- [x] **Step 8: Run focused tests**
 
 Run: `npx vitest run components/instrument/instrument-case-card.test.tsx components/instrument/print-case-card-controls.test.tsx components/instrument/instrument-spec.test.tsx`
 

--- a/docs/superpowers/plans/2026-06-19-instrument-records.md
+++ b/docs/superpowers/plans/2026-06-19-instrument-records.md
@@ -1180,7 +1180,7 @@ Open `http://localhost:3000/sn/RLY26001/print` and inspect print preview with:
 
 For every case, verify exactly one page, no clipped control text, no instrument photograph, no site header/footer, and visible site logo plus `K7RHY Resonance Lab`. Scan the rendered QR code with a phone and confirm it resolves to `https://k7rhy.app/sn/RLY26001`.
 
-- [ ] **Step 6: Commit verification-driven fixes and route coverage**
+- [x] **Step 6: Commit verification-driven fixes and route coverage**
 
 ```bash
 git add lib/instruments/route-resolution.ts lib/instruments/route-resolution.test.ts app/sn components/instrument content/instruments/RLY26001.mdx docs/superpowers/plans/2026-06-19-instrument-records.md

--- a/docs/superpowers/plans/2026-06-19-instrument-records.md
+++ b/docs/superpowers/plans/2026-06-19-instrument-records.md
@@ -35,6 +35,7 @@
 - `lib/instruments/serial.ts` — parse, normalize, validate, and construct canonical serial URLs.
 - `lib/instruments/validation.ts` — pure document validation used safely by the collection transform.
 - `lib/instruments/records.ts` — look up generated instrument records without entering the collection-config dependency graph.
+- `lib/instruments/visibility.ts` — production publication policy, isolated from generated content for focused tests.
 - `content-collections.ts` — add the `instruments` collection and expose derived serial/model data.
 - `content/instruments/RLY26001.mdx` — complete unpublished example/template record.
 - `content/instruments/README.md` — concise authoring and publication checklist.
@@ -381,9 +382,6 @@ export function getInstrumentStaticParams(): Array<{ serial: string }> {
     return allInstruments.map((instrument) => ({ serial: instrument.serial }));
 }
 
-export function isInstrumentPublished(record: InstrumentRecord): boolean {
-    return process.env.NEXT_PUBLIC_ENVIRONMENT !== 'production' || record.publish;
-}
 ```
 
 - [x] **Step 6: Add a complete unpublished MDX fixture/template**
@@ -671,7 +669,7 @@ Run: `npx vitest run components/instrument/instrument-spec.test.tsx`
 
 Expected: PASS, 6 tests.
 
-- [ ] **Step 6: Commit the strict MDX component system**
+- [x] **Step 6: Commit the strict MDX component system**
 
 ```bash
 git add components/instrument/instrument-spec.tsx components/instrument/instrument-spec.test.tsx components/instrument/instrument-mdx-components.tsx components/mdx-components.tsx
@@ -692,7 +690,7 @@ git commit -m "feat(instruments): add strict MDX control model"
 - Produces: the indexable canonical page at `/sn/[serial]`.
 - Produces: metadata title `${name} · ${serial} | K7RHY` and canonical URL.
 
-- [ ] **Step 1: Write failing presentation tests**
+- [x] **Step 1: Write failing presentation tests**
 
 ```tsx
 import React from 'react';
@@ -728,13 +726,13 @@ describe('InstrumentRecordPage', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and verify it fails**
+- [x] **Step 2: Run the test and verify it fails**
 
 Run: `npx vitest run components/instrument/instrument-record-page.test.tsx`
 
 Expected: FAIL because `InstrumentRecordPage` does not exist.
 
-- [ ] **Step 3: Implement the site-aligned record presentation**
+- [x] **Step 3: Implement the site-aligned record presentation**
 
 `InstrumentRecordPage` must:
 
@@ -778,7 +776,7 @@ export function InstrumentRecordPage({ record, children }: InstrumentRecordPageP
 
 Import `Image` from `next/image`, `Link` from `next/link`, React, and the `InstrumentRecord` type. Do not add a custom header or footer; `app/layout.tsx` already supplies the standard site frame.
 
-- [ ] **Step 4: Implement the canonical route**
+- [x] **Step 4: Implement the canonical route**
 
 ```tsx
 // app/sn/[serial]/page.tsx
@@ -787,8 +785,9 @@ import { notFound, redirect } from 'next/navigation';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { InstrumentRecordPage } from '@/components/instrument/instrument-record-page';
 import { instrumentMdxComponents } from '@/components/instrument/instrument-mdx-components';
-import { getInstrument, getInstrumentStaticParams, isInstrumentPublished } from '@/lib/instruments/records';
+import { getInstrument, getInstrumentStaticParams } from '@/lib/instruments/records';
 import { instrumentUrl, normalizeInstrumentSerial } from '@/lib/instruments/serial';
+import { isInstrumentPublished } from '@/lib/instruments/visibility';
 
 interface Props { params: Promise<{ serial: string }> }
 
@@ -819,7 +818,7 @@ export default async function InstrumentPage({ params }: Props) {
 }
 ```
 
-- [ ] **Step 5: Run focused tests and a route build**
+- [x] **Step 5: Run focused tests and a route build**
 
 Run: `npx vitest run components/instrument/instrument-record-page.test.tsx && npx next build`
 

--- a/docs/superpowers/plans/2026-06-19-instrument-records.md
+++ b/docs/superpowers/plans/2026-06-19-instrument-records.md
@@ -1,0 +1,1221 @@
+# Serialized Instrument Records Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish validated, serial-numbered instrument pages and one-page printable case cards from strict MDX documents.
+
+**Architecture:** A new Content Collections collection validates document-level instrument metadata and derives the serial from each filename. Strict compound React components validate and render pickup/control structures from MDX; the canonical web route and print route render that same MDX source in site-aligned presentations. QR codes, Discord support, model descriptions, and canonical URLs are derived centrally so records cannot drift.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript strict mode, MDX via `next-mdx-remote/rsc`, Content Collections + Zod, Tailwind CSS, CSS print media, Vitest + Testing Library, `qrcode.react`.
+
+## Global Constraints
+
+- Canonical serial format is exactly `MMMYYNNN`: three uppercase letters, two decimal year digits, and three decimal index digits.
+- Public routes are only `/sn/[serial]` and `/sn/[serial]/print`; lowercase serials redirect to uppercase.
+- Instrument documents live at `content/instruments/<SERIAL>.mdx`; serial is derived from the filename and never duplicated in frontmatter.
+- Records are public and indexable but are not added to a registry or navigation listing.
+- `publish: false` records return 404 in production.
+- No owner names, transfer history, database, web editor, service-management system, or generated PDF pipeline.
+- Web records retain the standard site header, navigation, dark mode, and footer.
+- Web pages require a photograph of the exact instrument; print cards contain no instrument photograph.
+- Case cards target one portrait US Letter page and scale safely to one portrait A4 page.
+- The case-card masthead uses `public/images/k7rhy_logo.png` and the full text `K7RHY Resonance Lab`.
+- Case cards prioritize voices and control access; provenance is communicated through maker, serial, year, components, and permanent URL without an authenticity claim.
+- Selector numbering is inferred from child order; authors never enter selector position numbers.
+- Push-pull and push-push pots explicitly author `down` and `up`; standard pots author `normal`.
+- Discord always comes from `config/site.ts`; QR codes always encode `https://k7rhy.app/sn/<SERIAL>`.
+- Follow repository formatting: 4-space indentation, single quotes, trailing commas where supported, and no manual print-width wrapping.
+
+---
+
+## File Structure
+
+- `config/instrument-model-codes.ts` — editable code-to-description table only.
+- `types/instrument.ts` — frontmatter, generated record, serial, image, and related-link contracts.
+- `lib/instruments/serial.ts` — parse, normalize, validate, and construct canonical serial URLs.
+- `lib/instruments/validation.ts` — pure document validation used safely by the collection transform.
+- `lib/instruments/records.ts` — look up generated instrument records without entering the collection-config dependency graph.
+- `content-collections.ts` — add the `instruments` collection and expose derived serial/model data.
+- `content/instruments/RLY26001.mdx` — complete unpublished example/template record.
+- `content/instruments/README.md` — concise authoring and publication checklist.
+- `components/instrument/instrument-spec.tsx` — strict compound MDX components and runtime child validation.
+- `components/instrument/instrument-mdx-components.tsx` — instrument MDX component registration.
+- `components/instrument/instrument-record-page.tsx` — web presentation around rendered MDX.
+- `components/instrument/instrument-case-card.tsx` — printable identity/card presentation and QR code.
+- `components/instrument/print-case-card-controls.tsx` — client-only print invocation and fallback button.
+- `app/sn/[serial]/page.tsx` — canonical public record route and metadata.
+- `app/sn/[serial]/print/page.tsx` — dedicated card route.
+- `app/sn/instrument-records.css` — screen and print layout, `@page`, Letter/A4 safeguards, and monochrome rules.
+- Focused colocated `*.test.ts(x)` files — pure validation and rendering tests.
+
+---
+
+### Task 1: Serial Numbers and Editable Model-Code Registry
+
+**Files:**
+- Create: `config/instrument-model-codes.ts`
+- Create: `types/instrument.ts`
+- Create: `lib/instruments/serial.ts`
+- Test: `lib/instruments/serial.test.ts`
+
+**Interfaces:**
+- Produces: `INSTRUMENT_MODEL_CODES: Record<string, string>`
+- Produces: `parseInstrumentSerial(input: string): InstrumentSerial`
+- Produces: `normalizeInstrumentSerial(input: string): string`
+- Produces: `instrumentPath(serial: string): string`
+- Produces: `instrumentUrl(serial: string): string`
+
+- [ ] **Step 1: Write failing serial tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { instrumentPath, instrumentUrl, normalizeInstrumentSerial, parseInstrumentSerial } from './serial';
+
+describe('instrument serials', () => {
+    it('parses a known MMMYYNNN serial', () => {
+        expect(parseInstrumentSerial('RLY26001')).toEqual({
+            serial: 'RLY26001',
+            modelCode: 'RLY',
+            modelDescription: 'Relay',
+            year: 2026,
+            index: 1,
+        });
+    });
+
+    it('normalizes lowercase input before routing', () => {
+        expect(normalizeInstrumentSerial('rly26001')).toBe('RLY26001');
+    });
+
+    it.each(['RLY-26001', 'RLY2601', 'R1Y26001', 'RLY26ABC'])('rejects malformed serial %s', (serial) => {
+        expect(() => parseInstrumentSerial(serial)).toThrow(`Invalid instrument serial: ${serial}`);
+    });
+
+    it('rejects an unknown model code', () => {
+        expect(() => parseInstrumentSerial('ZZZ26001')).toThrow('Unknown instrument model code: ZZZ');
+    });
+
+    it('builds canonical paths and production URLs', () => {
+        expect(instrumentPath('rly26001')).toBe('/sn/RLY26001');
+        expect(instrumentUrl('RLY26001')).toBe('https://k7rhy.app/sn/RLY26001');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx vitest run lib/instruments/serial.test.ts`
+
+Expected: FAIL because `./serial` does not exist.
+
+- [ ] **Step 3: Add the editable registry and shared types**
+
+```ts
+// config/instrument-model-codes.ts
+export const INSTRUMENT_MODEL_CODES: Readonly<Record<string, string>> = {
+    RLY: 'Relay',
+    FND: 'Fender',
+    GIB: 'Gibson',
+    PRS: 'PRS',
+    TEL: 'Telecaster-style',
+    STR: 'Stratocaster-style',
+    LES: 'Les Paul-style',
+};
+```
+
+```ts
+// types/instrument.ts
+export interface InstrumentSerial {
+    serial: string;
+    modelCode: string;
+    modelDescription: string;
+    year: number;
+    index: number;
+}
+
+export interface InstrumentImage {
+    src: string;
+    alt: string;
+}
+
+export interface InstrumentRelatedLink {
+    label: string;
+    href: string;
+}
+
+export interface InstrumentFrontmatter {
+    publish: boolean;
+    name: string;
+    completed: string;
+    origin: string;
+    theme: string;
+    images: InstrumentImage[];
+    related?: InstrumentRelatedLink;
+    content: string;
+}
+
+export interface InstrumentRecord extends InstrumentFrontmatter, InstrumentSerial {}
+```
+
+- [ ] **Step 4: Implement serial parsing and URL construction**
+
+```ts
+// lib/instruments/serial.ts
+import { INSTRUMENT_MODEL_CODES } from '@/config/instrument-model-codes';
+import type { InstrumentSerial } from '@/types/instrument';
+
+const SERIAL_PATTERN = /^([A-Z]{3})(\d{2})(\d{3})$/;
+
+export function normalizeInstrumentSerial(input: string): string {
+    return input.trim().toUpperCase();
+}
+
+export function parseInstrumentSerial(input: string): InstrumentSerial {
+    const serial = normalizeInstrumentSerial(input);
+    const match = SERIAL_PATTERN.exec(serial);
+
+    if (!match) {
+        throw new Error(`Invalid instrument serial: ${input}`);
+    }
+
+    const [, modelCode, yearPart, indexPart] = match;
+    const modelDescription = INSTRUMENT_MODEL_CODES[modelCode];
+
+    if (!modelDescription) {
+        throw new Error(`Unknown instrument model code: ${modelCode}`);
+    }
+
+    return {
+        serial,
+        modelCode,
+        modelDescription,
+        year: 2000 + Number(yearPart),
+        index: Number(indexPart),
+    };
+}
+
+export function instrumentPath(serial: string): string {
+    return `/sn/${parseInstrumentSerial(serial).serial}`;
+}
+
+export function instrumentUrl(serial: string): string {
+    return `https://k7rhy.app${instrumentPath(serial)}`;
+}
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `npx vitest run lib/instruments/serial.test.ts`
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 6: Commit the serial foundation**
+
+```bash
+git add config/instrument-model-codes.ts types/instrument.ts lib/instruments/serial.ts lib/instruments/serial.test.ts
+git commit -m "feat(instruments): add serial number model"
+```
+
+---
+
+### Task 2: Validated Instrument Content Collection
+
+**Files:**
+- Create: `lib/instruments/validation.ts`
+- Test: `lib/instruments/validation.test.ts`
+- Create: `lib/instruments/records.ts`
+- Modify: `content-collections.ts`
+- Create: `content/instruments/RLY26001.mdx`
+- Create: `content/instruments/README.md`
+
+**Interfaces:**
+- Consumes: `parseInstrumentSerial()` and `InstrumentFrontmatter` from Task 1.
+- Produces: `validateInstrumentDocument(path: string, data: InstrumentFrontmatter): InstrumentRecord` from a pure module with no generated-content import.
+- Produces: generated `allInstruments` and `Instrument` type from `content-collections`.
+- Produces: `getInstrument(serial: string)` and `getInstrumentStaticParams()`.
+
+- [ ] **Step 1: Write failing document-validation tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { InstrumentFrontmatter } from '@/types/instrument';
+import { validateInstrumentDocument } from './validation';
+
+const valid: InstrumentFrontmatter = {
+    publish: false,
+    name: 'Relay Lipstick',
+    completed: '2026-06-19',
+    origin: 'Designed, built, and voiced by K7RHY Resonance Lab.',
+    theme: 'Articulate and touch-sensitive.',
+    images: [{ src: '/images/products/guitars/rainbow-tele/front.jpeg', alt: 'RLY26001 front view' }],
+    related: { label: 'Explore Relay Guitar', href: '/relay' },
+    content: '<InstrumentSpec />',
+};
+
+describe('validateInstrumentDocument', () => {
+    it('derives serial data from the MDX path', () => {
+        expect(validateInstrumentDocument('RLY26001', valid)).toMatchObject({ serial: 'RLY26001', modelDescription: 'Relay' });
+    });
+
+    it('requires at least one exact-instrument image', () => {
+        expect(() => validateInstrumentDocument('RLY26001', { ...valid, images: [] })).toThrow('RLY26001 requires at least one instrument image');
+    });
+
+    it('requires a local absolute image path and useful alt text', () => {
+        expect(() => validateInstrumentDocument('RLY26001', { ...valid, images: [{ src: 'front.jpg', alt: '' }] })).toThrow('RLY26001 has an invalid instrument image');
+    });
+
+    it('rejects an image path that does not exist under public', () => {
+        expect(() => validateInstrumentDocument('RLY26001', { ...valid, images: [{ src: '/images/instruments/missing.jpg', alt: 'Missing image' }] })).toThrow('RLY26001 image does not exist: /images/instruments/missing.jpg');
+    });
+
+    it('requires the serial year to match the completion date', () => {
+        expect(() => validateInstrumentDocument('RLY26001', { ...valid, completed: '2025-12-31' })).toThrow('RLY26001 year does not match completion date 2025-12-31');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx vitest run lib/instruments/validation.test.ts`
+
+Expected: FAIL because `validation.ts` does not exist.
+
+- [ ] **Step 3: Implement pure document validation**
+
+```ts
+// lib/instruments/validation.ts
+import { existsSync } from 'fs';
+import { join } from 'path';
+import type { InstrumentFrontmatter, InstrumentRecord } from '@/types/instrument';
+import { parseInstrumentSerial } from './serial';
+
+export function validateInstrumentDocument(path: string, data: InstrumentFrontmatter): InstrumentRecord {
+    const serialData = parseInstrumentSerial(path);
+
+    if (data.images.length === 0) {
+        throw new Error(`${serialData.serial} requires at least one instrument image`);
+    }
+
+    const completedYear = Number(data.completed.slice(0, 4));
+    if (completedYear !== serialData.year) {
+        throw new Error(`${serialData.serial} year does not match completion date ${data.completed}`);
+    }
+
+    for (const image of data.images) {
+        if (!image.src.startsWith('/') || image.alt.trim().length === 0) {
+            throw new Error(`${serialData.serial} has an invalid instrument image`);
+        }
+        const absolutePath = join(process.cwd(), 'public', image.src.replace(/^\//, ''));
+        if (!existsSync(absolutePath)) {
+            throw new Error(`${serialData.serial} image does not exist: ${image.src}`);
+        }
+    }
+
+    return { ...data, ...serialData };
+}
+```
+
+- [ ] **Step 4: Add the instrument schema and transform to Content Collections**
+
+Add these definitions after `blogSchema` in `content-collections.ts`:
+
+```ts
+const instrumentSchema = z.object({
+    publish: z.boolean().optional().default(false),
+    name: z.string().min(1),
+    completed: z.string().date('Invalid completion date.'),
+    origin: z.string().min(1),
+    theme: z.string().min(1),
+    images: z.array(
+        z.object({
+            src: z.string().min(1),
+            alt: z.string().min(1),
+        }),
+    ),
+    related: z
+        .object({
+            label: z.string().min(1),
+            href: z.string().startsWith('/'),
+        })
+        .optional(),
+    content: z.string(),
+});
+```
+
+Add the import and collection:
+
+```ts
+import { validateInstrumentDocument } from './lib/instruments/validation';
+
+const instruments = defineCollection({
+    name: 'instruments',
+    directory: 'content/instruments',
+    include: '**/*.mdx',
+    schema: instrumentSchema,
+    transform: async (data) => validateInstrumentDocument(data._meta.path, data),
+});
+```
+
+Change the final config to:
+
+```ts
+export default defineConfig({
+    collections: [blog, instruments],
+});
+```
+
+- [ ] **Step 5: Add generated-record lookup outside the collection dependency graph**
+
+```ts
+// lib/instruments/records.ts
+import { allInstruments } from 'content-collections';
+import type { InstrumentRecord } from '@/types/instrument';
+import { normalizeInstrumentSerial } from './serial';
+
+export function getInstrument(serial: string): InstrumentRecord | undefined {
+    const normalized = normalizeInstrumentSerial(serial);
+    return allInstruments.find((instrument) => instrument.serial === normalized) as InstrumentRecord | undefined;
+}
+
+export function getInstrumentStaticParams(): Array<{ serial: string }> {
+    return allInstruments.map((instrument) => ({ serial: instrument.serial }));
+}
+
+export function isInstrumentPublished(record: InstrumentRecord): boolean {
+    return process.env.NEXT_PUBLIC_ENVIRONMENT !== 'production' || record.publish;
+}
+```
+
+- [ ] **Step 6: Add a complete unpublished MDX fixture/template**
+
+Create `content/instruments/RLY26001.mdx`:
+
+```mdx
+---
+publish: false
+name: 'Relay Lipstick'
+completed: '2026-06-19'
+origin: 'Designed, built, and voiced by K7RHY Resonance Lab.'
+theme: 'An articulate, touch-sensitive instrument with a familiar core and one carefully shaped alternate identity.'
+images:
+    - src: '/images/products/guitars/rainbow-tele/front.jpeg'
+      alt: 'Example instrument photograph used while developing the serialized record template'
+related:
+    label: 'Explore the Relay Guitar family'
+    href: '/relay'
+---
+
+<InstrumentSpec>
+    <PickupConfiguration>
+        <Pickup position="bridge" type="humbucker" brand="GFS" model="VEH">
+            <PickupDetail label="Magnet">Alnico V</PickupDetail>
+        </Pickup>
+        <Pickup position="middle" type="lipstick" brand="GFS" model="Pro-Tube" />
+        <Pickup position="neck" type="humbucker" brand="GFS" model="Professional Alnico II" />
+    </PickupConfiguration>
+
+    <ControlLayout>
+        <Selector label="Pickup selector" positions={3}>
+            <SelectorPosition voice="Bridge">Authority and attack</SelectorPosition>
+            <SelectorPosition voice="Bridge + Neck">Width and balance</SelectorPosition>
+            <SelectorPosition voice="Neck">Warmth and detail</SelectorPosition>
+        </Selector>
+        <Pot label="Master volume" mechanism="push-pull">
+            <PotPosition position="down" voice="Core voice">Controls overall output.</PotPosition>
+            <PotPosition position="up" voice="Lipstick Voice">Adds the middle lipstick and reshapes the bridge response.</PotPosition>
+        </Pot>
+        <Pot label="Master tone" mechanism="push-push">
+            <PotPosition position="down" voice="Open contour">Standard treble rolloff.</PotPosition>
+            <PotPosition position="up" voice="Focused contour">Tightens and focuses the response.</PotPosition>
+        </Pot>
+    </ControlLayout>
+</InstrumentSpec>
+
+## This instrument
+
+This unpublished example establishes the authoring shape for future serialized instruments. Replace the photograph and copy before using it as a real owner record.
+```
+
+- [ ] **Step 7: Add the authoring checklist**
+
+```md
+# Serialized instrument authoring
+
+1. Add or edit the three-letter description in `config/instrument-model-codes.ts`.
+2. Copy `RLY26001.mdx` to the new uppercase `MMMYYNNN.mdx` filename.
+3. Keep `publish: false` while replacing every identity field, image, pickup, selector, and pot state.
+4. Put exact-instrument photographs under `public/images/instruments/<SERIAL>/` and give each useful alt text.
+5. Run `npx content-collections build` and `npx vitest run`.
+6. Preview `/sn/<SERIAL>` in light, dark, desktop, and mobile layouts.
+7. Preview `/sn/<SERIAL>/print` on Letter and A4 and scan its QR code.
+8. Set `publish: true`, rerun `npm run build`, and deploy.
+
+Selector children are numbered from their order. Three-way selectors require three children; five-way selectors require five. Standard pots require one `normal` position. Push-pull and push-push pots require one `down` and one `up` position.
+```
+
+- [ ] **Step 8: Generate content and run validation tests**
+
+Run: `npx content-collections build && npx vitest run lib/instruments/validation.test.ts lib/instruments/serial.test.ts`
+
+Expected: generated declarations include `Instrument` and `allInstruments`; all focused tests PASS.
+
+- [ ] **Step 9: Commit the content pipeline**
+
+```bash
+git add content-collections.ts content/instruments/RLY26001.mdx content/instruments/README.md lib/instruments/validation.ts lib/instruments/validation.test.ts lib/instruments/records.ts
+git commit -m "feat(instruments): add validated MDX records"
+```
+
+---
+
+### Task 3: Strict Compound MDX Components
+
+**Files:**
+- Create: `components/instrument/instrument-spec.tsx`
+- Test: `components/instrument/instrument-spec.test.tsx`
+- Create: `components/instrument/instrument-mdx-components.tsx`
+- Modify: `components/mdx-components.tsx`
+
+**Interfaces:**
+- Produces: `InstrumentSpec`, `PickupConfiguration`, `Pickup`, `PickupDetail`, `ControlLayout`, `Selector`, `SelectorPosition`, `Pot`, and `PotPosition`.
+- Produces: `instrumentMdxComponents`, the mapping used by both routes.
+- Contract: invalid children throw serial-independent structural messages; route/build output provides the affected MDX path.
+
+- [ ] **Step 1: Write failing structural tests**
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ControlLayout, InstrumentSpec, Pickup, PickupConfiguration, Pot, PotPosition, Selector, SelectorPosition } from './instrument-spec';
+
+const pickups = (
+    <PickupConfiguration>
+        <Pickup position="bridge" type="humbucker" brand="GFS" model="VEH" />
+    </PickupConfiguration>
+);
+
+describe('instrument MDX components', () => {
+    it('numbers selector children from their sequence', () => {
+        render(
+            <Selector label="Pickup selector" positions={3}>
+                <SelectorPosition voice="Bridge">Attack</SelectorPosition>
+                <SelectorPosition voice="Both">Balance</SelectorPosition>
+                <SelectorPosition voice="Neck">Warmth</SelectorPosition>
+            </Selector>,
+        );
+        expect(screen.getByText('1')).toBeInTheDocument();
+        expect(screen.getByText('2')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('rejects a selector whose child count does not match', () => {
+        expect(() =>
+            render(
+                <Selector label="Pickup selector" positions={3}>
+                    <SelectorPosition voice="Bridge">Attack</SelectorPosition>
+                    <SelectorPosition voice="Neck">Warmth</SelectorPosition>
+                </Selector>,
+            ),
+        ).toThrow('Pickup selector declares 3 positions but contains 2');
+    });
+
+    it('rejects switched pots without down and up states', () => {
+        expect(() =>
+            render(
+                <Pot label="Volume" mechanism="push-pull">
+                    <PotPosition position="down" voice="Core">Output</PotPosition>
+                </Pot>,
+            ),
+        ).toThrow('Volume push-pull requires exactly one down and one up position');
+    });
+
+    it('rejects a spec missing a control layout', () => {
+        expect(() => render(<InstrumentSpec>{pickups}</InstrumentSpec>)).toThrow('InstrumentSpec requires exactly one PickupConfiguration and one ControlLayout');
+    });
+
+    it('renders valid pickup, selector, and push-push content', () => {
+        render(
+            <InstrumentSpec>
+                {pickups}
+                <ControlLayout>
+                    <Selector label="Selector" positions={3}>
+                        <SelectorPosition voice="Bridge">Attack</SelectorPosition>
+                        <SelectorPosition voice="Both">Balance</SelectorPosition>
+                        <SelectorPosition voice="Neck">Warmth</SelectorPosition>
+                    </Selector>
+                    <Pot label="Tone" mechanism="push-push">
+                        <PotPosition position="down" voice="Open">Standard rolloff</PotPosition>
+                        <PotPosition position="up" voice="Focused">Tighter response</PotPosition>
+                    </Pot>
+                </ControlLayout>
+            </InstrumentSpec>,
+        );
+        expect(screen.getByText('GFS VEH')).toBeInTheDocument();
+        expect(screen.getByText('Focused')).toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx vitest run components/instrument/instrument-spec.test.tsx`
+
+Expected: FAIL because `instrument-spec.tsx` does not exist.
+
+- [ ] **Step 3: Implement strict child collection and component contracts**
+
+Implement `components/instrument/instrument-spec.tsx` with these exact public prop types:
+
+```tsx
+import React from 'react';
+
+type SelectorCount = 3 | 5;
+type PotMechanism = 'standard' | 'push-pull' | 'push-push';
+type PotState = 'normal' | 'down' | 'up';
+
+export interface SelectorPositionProps {
+    voice: string;
+    children: React.ReactNode;
+    index?: number;
+}
+
+export interface PotPositionProps {
+    position: PotState;
+    voice: string;
+    children: React.ReactNode;
+}
+
+function elementChildren<P>(children: React.ReactNode, type: React.ComponentType<P>, parent: string): React.ReactElement<P>[] {
+    const result: React.ReactElement<P>[] = [];
+    React.Children.forEach(children, (child) => {
+        if (child === null || child === undefined || (typeof child === 'string' && child.trim() === '')) return;
+        if (!React.isValidElement<P>(child) || child.type !== type) {
+            throw new Error(`${parent} contains an unsupported child`);
+        }
+        result.push(child);
+    });
+    return result;
+}
+```
+
+Use `elementChildren` in every compound parent. The implementation must enforce:
+
+```tsx
+// Selector
+const items = elementChildren(children, SelectorPosition, label);
+if (items.length !== positions) throw new Error(`${label} declares ${positions} positions but contains ${items.length}`);
+return <ol>{items.map((item, index) => React.cloneElement(item, { index: index + 1 }))}</ol>;
+
+// Pot
+const items = elementChildren(children, PotPosition, label);
+const states = items.map((item) => item.props.position);
+const valid = mechanism === 'standard' ? states.length === 1 && states[0] === 'normal' : states.length === 2 && states.filter((state) => state === 'down').length === 1 && states.filter((state) => state === 'up').length === 1;
+if (!valid) throw new Error(mechanism === 'standard' ? `${label} standard requires exactly one normal position` : `${label} ${mechanism} requires exactly one down and one up position`);
+
+// InstrumentSpec
+export function InstrumentSpec({ children }: { children: React.ReactNode }) {
+    const pickups: React.ReactElement[] = [];
+    const controls: React.ReactElement[] = [];
+
+    React.Children.forEach(children, (child) => {
+        if (child === null || child === undefined || (typeof child === 'string' && child.trim() === '')) return;
+        if (!React.isValidElement(child)) throw new Error('InstrumentSpec contains an unsupported child');
+        if (child.type === PickupConfiguration) pickups.push(child);
+        else if (child.type === ControlLayout) controls.push(child);
+        else throw new Error('InstrumentSpec contains an unsupported child');
+    });
+
+    if (pickups.length !== 1 || controls.length !== 1) {
+        throw new Error('InstrumentSpec requires exactly one PickupConfiguration and one ControlLayout');
+    }
+
+    return (
+        <section data-instrument-spec className="space-y-6">
+            {controls[0]}
+            {pickups[0]}
+        </section>
+    );
+}
+```
+
+For `PickupConfiguration` and `ControlLayout`, call `elementChildren` with their single allowed child type and throw when their arrays are empty. `Pickup` concatenates `brand` and `model` in its heading and renders optional `PickupDetail` children in a `<dl>`. `SelectorPosition` renders its cloned `index` in a circular monospace marker plus `voice` and body copy. `PotPosition` renders its explicit state, voice, and body copy. Use semantic headings, ordered/unordered lists, and definition groups with `data-instrument-spec`, `data-control-layout`, and `data-pickup-configuration` attributes. Use Tailwind classes based on the approved slate/sky site language. Set `displayName` on every exported component for MDX/debug error clarity.
+
+- [ ] **Step 4: Register components for instrument MDX**
+
+```tsx
+// components/instrument/instrument-mdx-components.tsx
+import baseComponents from '@/components/mdx-components';
+import { ControlLayout, InstrumentSpec, Pickup, PickupConfiguration, PickupDetail, Pot, PotPosition, Selector, SelectorPosition } from './instrument-spec';
+
+export const instrumentMdxComponents = {
+    ...baseComponents,
+    InstrumentSpec,
+    PickupConfiguration,
+    Pickup,
+    PickupDetail,
+    ControlLayout,
+    Selector,
+    SelectorPosition,
+    Pot,
+    PotPosition,
+};
+```
+
+Also add the same named imports and mappings to `components/mdx-components.tsx` so instrument snippets remain recognized anywhere the shared MDX renderer is used.
+
+- [ ] **Step 5: Run focused component tests**
+
+Run: `npx vitest run components/instrument/instrument-spec.test.tsx`
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Commit the strict MDX component system**
+
+```bash
+git add components/instrument/instrument-spec.tsx components/instrument/instrument-spec.test.tsx components/instrument/instrument-mdx-components.tsx components/mdx-components.tsx
+git commit -m "feat(instruments): add strict MDX control model"
+```
+
+---
+
+### Task 4: Public Instrument Record Page
+
+**Files:**
+- Create: `components/instrument/instrument-record-page.tsx`
+- Test: `components/instrument/instrument-record-page.test.tsx`
+- Create: `app/sn/[serial]/page.tsx`
+
+**Interfaces:**
+- Consumes: `InstrumentRecord`, `getInstrument()`, `getInstrumentStaticParams()`, `isInstrumentPublished()`, and `instrumentMdxComponents`.
+- Produces: the indexable canonical page at `/sn/[serial]`.
+- Produces: metadata title `${name} · ${serial} | K7RHY` and canonical URL.
+
+- [ ] **Step 1: Write failing presentation tests**
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { InstrumentRecordPage } from './instrument-record-page';
+import type { InstrumentRecord } from '@/types/instrument';
+
+vi.mock('next/image', () => ({ default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} /> }));
+
+const record: InstrumentRecord = {
+    serial: 'RLY26001', modelCode: 'RLY', modelDescription: 'Relay', year: 2026, index: 1,
+    publish: true, name: 'Relay Lipstick', completed: '2026-06-19',
+    origin: 'Designed, built, and voiced by K7RHY Resonance Lab.', theme: 'Articulate and touch-sensitive.',
+    images: [{ src: '/images/instruments/RLY26001/front.jpg', alt: 'RLY26001 front view' }],
+    related: { label: 'Explore the Relay Guitar family', href: '/relay' }, content: '',
+};
+
+describe('InstrumentRecordPage', () => {
+    it('leads with identity, photograph, theme, and print action', () => {
+        render(<InstrumentRecordPage record={record}><div>Structured specification</div></InstrumentRecordPage>);
+        expect(screen.getByRole('heading', { level: 1, name: 'Relay Lipstick' })).toBeInTheDocument();
+        expect(screen.getByText('RLY26001')).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: 'RLY26001 front view' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /print case card/i })).toHaveAttribute('href', '/sn/RLY26001/print');
+    });
+
+    it('renders the optional discovery link without replacing site navigation', () => {
+        render(<InstrumentRecordPage record={record}><div>Structured specification</div></InstrumentRecordPage>);
+        expect(screen.getByRole('link', { name: 'Explore the Relay Guitar family' })).toHaveAttribute('href', '/relay');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx vitest run components/instrument/instrument-record-page.test.tsx`
+
+Expected: FAIL because `InstrumentRecordPage` does not exist.
+
+- [ ] **Step 3: Implement the site-aligned record presentation**
+
+`InstrumentRecordPage` must:
+
+```tsx
+export interface InstrumentRecordPageProps {
+    record: InstrumentRecord;
+    children: React.ReactNode;
+}
+
+export function InstrumentRecordPage({ record, children }: InstrumentRecordPageProps) {
+    const primaryImage = record.images[0];
+    return (
+        <main className="container mx-auto max-w-6xl space-y-8 px-4 py-8 md:px-8 md:py-12">
+            <section className="grid overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-sky-50 via-white to-emerald-50 shadow-lg dark:from-slate-950 dark:via-slate-950 dark:to-slate-900 lg:grid-cols-[1.1fr_0.9fr]">
+                <div className="space-y-5 p-7 md:p-10">
+                    <span className="inline-flex rounded-full border bg-background/80 px-3 py-1 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Individual instrument</span>
+                    <div className="font-mono text-sm tracking-[0.14em] text-sky-700 dark:text-sky-300">{record.serial}</div>
+                    <h1 className="text-4xl font-semibold tracking-tight md:text-5xl">{record.name}</h1>
+                    <p className="max-w-2xl text-lg text-muted-foreground">{record.theme}</p>
+                    <dl className="grid gap-4 border-t pt-5 text-sm sm:grid-cols-2">
+                        <div><dt className="font-mono text-xs uppercase tracking-wider text-muted-foreground">Origin</dt><dd className="mt-1">{record.origin}</dd></div>
+                        <div><dt className="font-mono text-xs uppercase tracking-wider text-muted-foreground">Completed</dt><dd className="mt-1">{record.completed}</dd></div>
+                    </dl>
+                    <Link href={`/sn/${record.serial}/print`} className="inline-flex rounded-lg border bg-background px-4 py-2 text-sm font-semibold shadow-sm">Print case card</Link>
+                </div>
+                <div className="relative min-h-80 bg-slate-100 dark:bg-slate-900">
+                    <Image src={primaryImage.src} alt={primaryImage.alt} fill priority className="object-cover" sizes="(min-width: 1024px) 40vw, 100vw" />
+                </div>
+            </section>
+            <article className="space-y-8">{children}</article>
+            {record.related && (
+                <aside className="flex flex-col gap-4 rounded-2xl border border-sky-200 bg-sky-50 p-6 dark:border-sky-900 dark:bg-sky-950/30 sm:flex-row sm:items-center sm:justify-between">
+                    <div><h2 className="font-semibold">Continue exploring</h2><p className="text-sm text-muted-foreground">See how this instrument fits into the wider K7RHY work.</p></div>
+                    <Link href={record.related.href} className="font-semibold text-sky-800 hover:underline dark:text-sky-300">{record.related.label}</Link>
+                </aside>
+            )}
+        </main>
+    );
+}
+```
+
+Import `Image` from `next/image`, `Link` from `next/link`, React, and the `InstrumentRecord` type. Do not add a custom header or footer; `app/layout.tsx` already supplies the standard site frame.
+
+- [ ] **Step 4: Implement the canonical route**
+
+```tsx
+// app/sn/[serial]/page.tsx
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import { InstrumentRecordPage } from '@/components/instrument/instrument-record-page';
+import { instrumentMdxComponents } from '@/components/instrument/instrument-mdx-components';
+import { getInstrument, getInstrumentStaticParams, isInstrumentPublished } from '@/lib/instruments/records';
+import { instrumentUrl, normalizeInstrumentSerial } from '@/lib/instruments/serial';
+
+interface Props { params: Promise<{ serial: string }> }
+
+export function generateStaticParams() {
+    return getInstrumentStaticParams();
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { serial: input } = await params;
+    const serial = normalizeInstrumentSerial(input);
+    const record = getInstrument(serial);
+    if (!record || !isInstrumentPublished(record)) return {};
+    return { title: `${record.name} · ${serial} | K7RHY`, description: record.theme, alternates: { canonical: instrumentUrl(serial) } };
+}
+
+export default async function InstrumentPage({ params }: Props) {
+    const { serial: input } = await params;
+    const serial = normalizeInstrumentSerial(input);
+    if (input !== serial) redirect(`/sn/${serial}`);
+    const record = getInstrument(serial);
+    if (!record || !isInstrumentPublished(record)) notFound();
+
+    return (
+        <InstrumentRecordPage record={record}>
+            <MDXRemote source={record.content} components={instrumentMdxComponents} />
+        </InstrumentRecordPage>
+    );
+}
+```
+
+- [ ] **Step 5: Run focused tests and a route build**
+
+Run: `npx vitest run components/instrument/instrument-record-page.test.tsx && npx next build`
+
+Expected: component tests PASS; build emits `/sn/[serial]` and the unpublished fixture does not produce a public production page.
+
+- [ ] **Step 6: Commit the public record page**
+
+```bash
+git add components/instrument/instrument-record-page.tsx components/instrument/instrument-record-page.test.tsx app/sn/[serial]/page.tsx
+git commit -m "feat(instruments): add serial record pages"
+```
+
+---
+
+### Task 5: QR-Backed One-Page Case Card
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Create: `components/instrument/instrument-case-card.tsx`
+- Test: `components/instrument/instrument-case-card.test.tsx`
+- Create: `components/instrument/print-case-card-controls.tsx`
+- Test: `components/instrument/print-case-card-controls.test.tsx`
+- Create: `app/sn/[serial]/print/page.tsx`
+- Create: `app/sn/instrument-records.css`
+- Create: `app/sn/layout.tsx`
+
+**Interfaces:**
+- Consumes: the same `InstrumentRecord` and MDX source as Task 4.
+- Produces: `InstrumentCaseCard({ record, children })`.
+- Produces: QR SVG value from `instrumentUrl(record.serial)`.
+- Produces: browser print invocation with visible fallback button.
+
+- [ ] **Step 1: Install the QR renderer**
+
+Run: `npm install qrcode.react`
+
+Expected: `qrcode.react` appears in dependencies and the lockfile updates.
+
+- [ ] **Step 2: Write failing case-card tests**
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { InstrumentCaseCard } from './instrument-case-card';
+
+vi.mock('qrcode.react', () => ({ QRCodeSVG: ({ value }: { value: string }) => <svg aria-label="Instrument record QR code" data-value={value} /> }));
+
+const record = {
+    serial: 'RLY26001', modelCode: 'RLY', modelDescription: 'Relay', year: 2026, index: 1,
+    publish: true, name: 'Relay Lipstick', completed: '2026-06-19', origin: 'Built by K7RHY Resonance Lab.',
+    theme: 'Articulate and touch-sensitive.', images: [{ src: '/front.jpg', alt: 'Front' }], content: '',
+};
+
+describe('InstrumentCaseCard', () => {
+    it('renders the site logo and full brand name', () => {
+        render(<InstrumentCaseCard record={record}><div>Control map</div></InstrumentCaseCard>);
+        expect(screen.getByRole('img', { name: 'K7RHY Resonance Lab logo' })).toBeInTheDocument();
+        expect(screen.getByText('K7RHY Resonance Lab')).toBeInTheDocument();
+    });
+
+    it('renders identity, controls, Discord, and canonical QR destination', () => {
+        const { container } = render(<InstrumentCaseCard record={record}><div>Control map</div></InstrumentCaseCard>);
+        expect(screen.getByText('RLY26001')).toBeInTheDocument();
+        expect(screen.getByText('Control map')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /discord/i })).toHaveAttribute('href', 'https://discord.gg/BuUxCG4W6w');
+        expect(container.querySelector('[data-value="https://k7rhy.app/sn/RLY26001"]')).toBeInTheDocument();
+        expect(container.querySelector('img[src="/front.jpg"]')).not.toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 3: Write failing print-control test**
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { PrintCaseCardControls } from './print-case-card-controls';
+
+describe('PrintCaseCardControls', () => {
+    it('invokes print on mount and provides a fallback button', () => {
+        const print = vi.spyOn(window, 'print').mockImplementation(() => undefined);
+        render(<PrintCaseCardControls />);
+        expect(print).toHaveBeenCalledOnce();
+        expect(screen.getByRole('button', { name: 'Print case card' })).toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 4: Implement the case-card wrapper**
+
+```tsx
+// components/instrument/instrument-case-card.tsx
+import React from 'react';
+import Image from 'next/image';
+import { QRCodeSVG } from 'qrcode.react';
+import { siteConfig } from '@/config/site';
+import { instrumentUrl } from '@/lib/instruments/serial';
+import type { InstrumentRecord } from '@/types/instrument';
+
+export function InstrumentCaseCard({ record, children }: { record: InstrumentRecord; children: React.ReactNode }) {
+    const url = instrumentUrl(record.serial);
+    return (
+        <article className="instrument-case-card flex flex-col border border-slate-300 p-[0.32in] shadow-xl">
+            <header className="flex items-center justify-between border-b border-slate-300 pb-4">
+                <div className="flex items-center gap-3">
+                    <Image src="/images/k7rhy_logo.png" alt="K7RHY Resonance Lab logo" width={42} height={42} />
+                    <span className="text-lg font-bold">K7RHY Resonance Lab</span>
+                </div>
+                <span className="font-mono text-[9pt] uppercase tracking-[0.16em] text-slate-500">Voice &amp; control card</span>
+            </header>
+            <section className="py-5">
+                <div className="font-mono text-[9pt] tracking-[0.14em] text-sky-700">{record.serial} · {record.year}</div>
+                <h1 className="mt-1 text-3xl font-semibold tracking-tight">{record.name}</h1>
+                <p className="mt-2 max-w-[6.4in] text-[10pt] leading-relaxed text-slate-600">{record.theme}</p>
+            </section>
+            <section className="min-h-0 flex-1">{children}</section>
+            <section className="mt-4 grid grid-cols-[0.8in_1fr] gap-3 border-t border-slate-300 pt-3 text-[9pt]">
+                <span className="font-mono uppercase tracking-wider text-slate-500">Origin</span>
+                <span>{record.origin}</span>
+            </section>
+            <footer className="mt-4 flex items-end justify-between border-t border-slate-300 pt-4">
+                <div className="space-y-1 font-mono text-[8.5pt] text-slate-600">
+                    <div>{url}</div>
+                    <a href={siteConfig.links.discord} className="underline underline-offset-2">Questions? Join the K7RHY Discord</a>
+                </div>
+                <QRCodeSVG value={url} size={96} level="M" marginSize={1} title={`Open the record for ${record.serial}`} />
+            </footer>
+        </article>
+    );
+}
+```
+
+Do not access or render `record.images` in this component.
+
+- [ ] **Step 5: Implement automatic print with fallback**
+
+```tsx
+// components/instrument/print-case-card-controls.tsx
+'use client';
+
+import React, { useEffect } from 'react';
+
+export function PrintCaseCardControls() {
+    useEffect(() => {
+        window.print();
+    }, []);
+
+    return (
+        <div className="instrument-print-controls">
+            <button type="button" onClick={() => window.print()} className="rounded-lg border bg-background px-4 py-2 text-sm font-semibold shadow-sm">
+                Print case card
+            </button>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 6: Add nested route styling and one-page print constraints**
+
+```tsx
+// app/sn/layout.tsx
+import './instrument-records.css';
+export default function InstrumentLayout({ children }: { children: React.ReactNode }) {
+    return children;
+}
+```
+
+`app/sn/instrument-records.css` must contain:
+
+```css
+@page {
+    size: letter portrait;
+    margin: 0.35in;
+}
+
+.instrument-case-card {
+    width: min(100%, 7.8in);
+    min-height: 10.3in;
+    margin: 1.5rem auto;
+    background: white;
+    color: #0f172a;
+}
+
+@media print {
+    html,
+    body {
+        background: white !important;
+    }
+
+    header,
+    footer,
+    .instrument-print-controls,
+    [data-web-only] {
+        display: none !important;
+    }
+
+    .instrument-case-card {
+        width: 100%;
+        min-height: 0;
+        height: 10.3in;
+        margin: 0;
+        overflow: hidden;
+        break-after: avoid;
+        break-inside: avoid;
+        box-shadow: none;
+        print-color-adjust: exact;
+        -webkit-print-color-adjust: exact;
+    }
+
+    .instrument-print-mdx > :not([data-instrument-spec]) {
+        display: none !important;
+    }
+}
+
+@media print and (max-height: 10in) {
+    .instrument-case-card {
+        transform: scale(0.94);
+        transform-origin: top left;
+        width: 106.3829787%;
+    }
+}
+```
+
+Keep text at or above 9pt in print. Use explicit grid row limits and line clamping for theme/origin only if the full supplied text would otherwise produce a second page; never clamp control instructions.
+
+- [ ] **Step 7: Implement the print route**
+
+Create `app/sn/[serial]/print/page.tsx` with the same imports and `Props` type as the public route plus `InstrumentCaseCard` and `PrintCaseCardControls`. Use `resolveInstrumentRequest` from Task 6 when Task 6 is complete; until then use the same normalization, redirect, lookup, and publication conditions from Task 4. The component body is:
+
+```tsx
+<>
+    <PrintCaseCardControls />
+    <InstrumentCaseCard record={record}>
+        <div className="instrument-print-mdx">
+            <MDXRemote source={record.content} components={instrumentMdxComponents} />
+        </div>
+    </InstrumentCaseCard>
+</>
+```
+
+Export `generateStaticParams()` by returning `getInstrumentStaticParams()`. Implement `generateMetadata()` with title `Case card · ${record.name} · ${serial} | K7RHY` and `robots: { index: false, follow: false }` so the canonical instrument record, not the utility print route, appears in search.
+
+- [ ] **Step 8: Run focused tests**
+
+Run: `npx vitest run components/instrument/instrument-case-card.test.tsx components/instrument/print-case-card-controls.test.tsx components/instrument/instrument-spec.test.tsx`
+
+Expected: all tests PASS.
+
+- [ ] **Step 9: Commit the case-card route**
+
+```bash
+git add package.json package-lock.json components/instrument/instrument-case-card.tsx components/instrument/instrument-case-card.test.tsx components/instrument/print-case-card-controls.tsx components/instrument/print-case-card-controls.test.tsx app/sn/layout.tsx app/sn/instrument-records.css app/sn/[serial]/print/page.tsx
+git commit -m "feat(instruments): add printable case cards"
+```
+
+---
+
+### Task 6: Route Behavior, Accessibility, and Rendered Verification
+
+**Files:**
+- Test: `lib/instruments/route-resolution.test.ts`
+- Create: `lib/instruments/route-resolution.ts`
+- Modify only if verification finds defects: files introduced in Tasks 3–5
+- Modify: `docs/superpowers/plans/2026-06-19-instrument-records.md` (check off completed steps during execution)
+- Create or update at session stop: `.remember/remember.md`
+
+**Interfaces:**
+- Produces: `resolveInstrumentRequest(input: string, environment: string | undefined)` as a pure route-decision helper used by both pages.
+- Verifies: web/print parity, one-page output, theme consistency, header/footer presence, discovery CTA, logo/brand masthead, QR destination, and error behavior.
+
+- [ ] **Step 1: Write failing route-decision tests**
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { resolveInstrumentRequest } from './route-resolution';
+
+vi.mock('./records', () => ({
+    getInstrument: (serial: string) => serial === 'RLY26001' ? { serial, publish: false } : undefined,
+}));
+
+describe('resolveInstrumentRequest', () => {
+    it('redirects lowercase serials', () => {
+        expect(resolveInstrumentRequest('rly26001', 'development')).toEqual({ kind: 'redirect', location: '/sn/RLY26001' });
+    });
+
+    it('returns not-found for an unknown serial', () => {
+        expect(resolveInstrumentRequest('RLY26999', 'development')).toEqual({ kind: 'not-found' });
+    });
+
+    it('returns not-found for an unpublished production record', () => {
+        expect(resolveInstrumentRequest('RLY26001', 'production')).toEqual({ kind: 'not-found' });
+    });
+
+    it('returns the record outside production', () => {
+        expect(resolveInstrumentRequest('RLY26001', 'development')).toMatchObject({ kind: 'record', record: { serial: 'RLY26001' } });
+    });
+});
+```
+
+- [ ] **Step 2: Implement and adopt the route helper**
+
+```ts
+// lib/instruments/route-resolution.ts
+import type { InstrumentRecord } from '@/types/instrument';
+import { getInstrument } from './records';
+import { normalizeInstrumentSerial } from './serial';
+
+export type InstrumentRequestResolution =
+    | { kind: 'redirect'; location: string }
+    | { kind: 'not-found' }
+    | { kind: 'record'; record: InstrumentRecord };
+
+export function resolveInstrumentRequest(input: string, environment = process.env.NEXT_PUBLIC_ENVIRONMENT): InstrumentRequestResolution {
+    const serial = normalizeInstrumentSerial(input);
+    if (input !== serial) return { kind: 'redirect', location: `/sn/${serial}` };
+    const record = getInstrument(serial);
+    if (!record || (environment === 'production' && !record.publish)) return { kind: 'not-found' };
+    return { kind: 'record', record };
+}
+```
+
+Replace duplicated route decisions in both pages with this helper. The print page appends `/print` when redirecting a lowercase print URL.
+
+- [ ] **Step 3: Run the full automated suite and production build**
+
+Run: `npx vitest run && npm run build`
+
+Expected: all tests PASS; Next build and sitemap generation complete successfully without `GOOGLE_GENERATIVE_AI_API_KEY` because existing blog summaries are present/cached or summary generation safely skips.
+
+- [ ] **Step 4: Start the site and verify the web record**
+
+Temporarily set the example record to `publish: true` only for local verification, then run: `npm run dev`
+
+Verify at `http://localhost:3000/sn/RLY26001`:
+
+- Standard K7RHY header, navigation, dark-mode toggle, and footer are present.
+- Exact-instrument hero image, serial, theme, origin, and date are visible.
+- Every selector position is automatically numbered in source order.
+- Push-pull and push-push each show both explicit states.
+- Related Relay CTA and Discord link are keyboard reachable.
+- Mobile width has no horizontal overflow.
+- Dark mode keeps all text, borders, and controls readable.
+
+Restore `publish: false` after verification.
+
+- [ ] **Step 5: Verify Letter, A4, and monochrome print output**
+
+Open `http://localhost:3000/sn/RLY26001/print` and inspect print preview with:
+
+- Destination: Save to PDF
+- Paper: US Letter, portrait, scale 100%, margins default
+- Paper: A4, portrait, scale 100%, margins default
+- Background graphics both enabled and disabled
+- Color and black-and-white output
+
+For every case, verify exactly one page, no clipped control text, no instrument photograph, no site header/footer, and visible site logo plus `K7RHY Resonance Lab`. Scan the rendered QR code with a phone and confirm it resolves to `https://k7rhy.app/sn/RLY26001`.
+
+- [ ] **Step 6: Commit verification-driven fixes and route coverage**
+
+```bash
+git add lib/instruments/route-resolution.ts lib/instruments/route-resolution.test.ts app/sn components/instrument content/instruments/RLY26001.mdx docs/superpowers/plans/2026-06-19-instrument-records.md
+git commit -m "test(instruments): verify routes and print layout"
+```
+
+- [ ] **Step 7: Write the pause/resume handoff**
+
+Create or update `.remember/remember.md` with fewer than 20 lines:
+
+```md
+# Handoff
+
+## State
+Serialized instrument records are implemented through Task 6 on the current branch. The approved spec is `docs/superpowers/specs/2026-06-19-instrument-records-design.md`; the tracked execution checklist is `docs/superpowers/plans/2026-06-19-instrument-records.md`.
+
+## Next
+1. Replace the unpublished `RLY26001` template photograph/copy with the first real instrument.
+2. Run `npx vitest run && npm run build` after content edits.
+3. Check Letter and A4 print preview before setting `publish: true`.
+
+## Context
+Case cards are voice/control guides with quiet provenance. Keep the site header/footer on web records; never add owner data or a PDF-generation pipeline.
+```
+
+---
+
+## Completion Criteria
+
+- A valid published `content/instruments/<SERIAL>.mdx` produces both canonical routes.
+- Invalid filenames, unknown model codes, incomplete selectors, and incomplete pot states fail clearly.
+- The web page feels like an elevated K7RHY page and preserves all standard discovery paths.
+- The case card uses the actual site logo plus full brand name, emphasizes voices/controls, and prints on exactly one Letter or A4 page.
+- QR and Discord links derive centrally and work.
+- The full test suite and production build pass.
+- The plan checklist and `.remember/remember.md` make the next session immediately actionable.

--- a/docs/superpowers/plans/2026-06-19-instrument-records.md
+++ b/docs/superpowers/plans/2026-06-19-instrument-records.md
@@ -1072,7 +1072,7 @@ Run: `npx vitest run components/instrument/instrument-case-card.test.tsx compone
 
 Expected: all tests PASS.
 
-- [ ] **Step 9: Commit the case-card route**
+- [x] **Step 9: Commit the case-card route**
 
 ```bash
 git add package.json package-lock.json components/instrument/instrument-case-card.tsx components/instrument/instrument-case-card.test.tsx components/instrument/print-case-card-controls.tsx components/instrument/print-case-card-controls.test.tsx app/sn/layout.tsx app/sn/instrument-records.css app/sn/[serial]/print/page.tsx
@@ -1091,55 +1091,56 @@ git commit -m "feat(instruments): add printable case cards"
 - Create or update at session stop: `.remember/remember.md`
 
 **Interfaces:**
-- Produces: `resolveInstrumentRequest(input: string, environment: string | undefined)` as a pure route-decision helper used by both pages.
+- Produces: `resolveInstrumentRequest(input: string, environment: string | undefined, lookup: InstrumentRecordLookup)` as a pure route-decision helper used by both pages.
 - Verifies: web/print parity, one-page output, theme consistency, header/footer presence, discovery CTA, logo/brand masthead, QR destination, and error behavior.
 
-- [ ] **Step 1: Write failing route-decision tests**
+- [x] **Step 1: Write failing route-decision tests**
 
 ```ts
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import type { InstrumentRecord } from '@/types/instrument';
 import { resolveInstrumentRequest } from './route-resolution';
 
-vi.mock('./records', () => ({
-    getInstrument: (serial: string) => serial === 'RLY26001' ? { serial, publish: false } : undefined,
-}));
+const unpublished = { serial: 'RLY26001', publish: false } as InstrumentRecord;
+const lookup = (serial: string) => serial === 'RLY26001' ? unpublished : undefined;
 
 describe('resolveInstrumentRequest', () => {
     it('redirects lowercase serials', () => {
-        expect(resolveInstrumentRequest('rly26001', 'development')).toEqual({ kind: 'redirect', location: '/sn/RLY26001' });
+        expect(resolveInstrumentRequest('rly26001', 'development', lookup)).toEqual({ kind: 'redirect', location: '/sn/RLY26001' });
     });
 
     it('returns not-found for an unknown serial', () => {
-        expect(resolveInstrumentRequest('RLY26999', 'development')).toEqual({ kind: 'not-found' });
+        expect(resolveInstrumentRequest('RLY26999', 'development', lookup)).toEqual({ kind: 'not-found' });
     });
 
     it('returns not-found for an unpublished production record', () => {
-        expect(resolveInstrumentRequest('RLY26001', 'production')).toEqual({ kind: 'not-found' });
+        expect(resolveInstrumentRequest('RLY26001', 'production', lookup)).toEqual({ kind: 'not-found' });
     });
 
     it('returns the record outside production', () => {
-        expect(resolveInstrumentRequest('RLY26001', 'development')).toMatchObject({ kind: 'record', record: { serial: 'RLY26001' } });
+        expect(resolveInstrumentRequest('RLY26001', 'development', lookup)).toEqual({ kind: 'record', record: unpublished });
     });
 });
 ```
 
-- [ ] **Step 2: Implement and adopt the route helper**
+- [x] **Step 2: Implement and adopt the route helper**
 
 ```ts
 // lib/instruments/route-resolution.ts
 import type { InstrumentRecord } from '@/types/instrument';
-import { getInstrument } from './records';
 import { normalizeInstrumentSerial } from './serial';
+
+export type InstrumentRecordLookup = (serial: string) => InstrumentRecord | undefined;
 
 export type InstrumentRequestResolution =
     | { kind: 'redirect'; location: string }
     | { kind: 'not-found' }
     | { kind: 'record'; record: InstrumentRecord };
 
-export function resolveInstrumentRequest(input: string, environment = process.env.NEXT_PUBLIC_ENVIRONMENT): InstrumentRequestResolution {
+export function resolveInstrumentRequest(input: string, environment: string | undefined, lookup: InstrumentRecordLookup): InstrumentRequestResolution {
     const serial = normalizeInstrumentSerial(input);
     if (input !== serial) return { kind: 'redirect', location: `/sn/${serial}` };
-    const record = getInstrument(serial);
+    const record = lookup(serial);
     if (!record || (environment === 'production' && !record.publish)) return { kind: 'not-found' };
     return { kind: 'record', record };
 }
@@ -1147,15 +1148,15 @@ export function resolveInstrumentRequest(input: string, environment = process.en
 
 Replace duplicated route decisions in both pages with this helper. The print page appends `/print` when redirecting a lowercase print URL.
 
-- [ ] **Step 3: Run the full automated suite and production build**
+- [x] **Step 3: Run the full automated suite and production build**
 
 Run: `npx vitest run && npm run build`
 
 Expected: all tests PASS; Next build and sitemap generation complete successfully without `GOOGLE_GENERATIVE_AI_API_KEY` because existing blog summaries are present/cached or summary generation safely skips.
 
-- [ ] **Step 4: Start the site and verify the web record**
+- [x] **Step 4: Start the site and verify the web record**
 
-Temporarily set the example record to `publish: true` only for local verification, then run: `npm run dev`
+Run `npm run dev`; development mode previews the unpublished fixture without changing its publication state.
 
 Verify at `http://localhost:3000/sn/RLY26001`:
 
@@ -1167,9 +1168,7 @@ Verify at `http://localhost:3000/sn/RLY26001`:
 - Mobile width has no horizontal overflow.
 - Dark mode keeps all text, borders, and controls readable.
 
-Restore `publish: false` after verification.
-
-- [ ] **Step 5: Verify Letter, A4, and monochrome print output**
+- [x] **Step 5: Verify Letter, A4, and monochrome print output**
 
 Open `http://localhost:3000/sn/RLY26001/print` and inspect print preview with:
 
@@ -1188,7 +1187,7 @@ git add lib/instruments/route-resolution.ts lib/instruments/route-resolution.tes
 git commit -m "test(instruments): verify routes and print layout"
 ```
 
-- [ ] **Step 7: Write the pause/resume handoff**
+- [x] **Step 7: Write the pause/resume handoff**
 
 Create or update `.remember/remember.md` with fewer than 20 lines:
 

--- a/docs/superpowers/plans/2026-06-22-sample-instrument-record.md
+++ b/docs/superpowers/plans/2026-06-22-sample-instrument-record.md
@@ -1,0 +1,57 @@
+# Sample Instrument Record Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a polished `RLY26001` demonstration record that lets the owner review both the web detail page and printable case card.
+
+**Architecture:** Reuse the validated instrument MDX collection, existing record route, compound control components, and current Rainbow Tele photography. This is a content-only change: no component, schema, route, or styling behavior changes.
+
+**Tech Stack:** Next.js 15 App Router, MDX, Content Collections, React 19, Tailwind CSS.
+
+## Global Constraints
+
+- Preserve the approved `MMMYYNNN` serial format and `/sn/<SERIAL>` route.
+- Keep the site header, footer, typography, colors, branding, QR destination, and one-page case-card layout unchanged.
+- Exercise the three-way selector, push-pull volume, and push-push tone structures with complete position descriptions.
+- Use only imagery already present in the repository.
+
+---
+
+### Task 1: Publish and polish the demonstration record
+
+**Files:**
+- Modify: `content/instruments/RLY26001.mdx`
+
+**Interfaces:**
+- Consumes: the existing `InstrumentSpec`, `PickupConfiguration`, `Pickup`, `PickupDetail`, `ControlLayout`, `Selector`, `SelectorPosition`, `Pot`, and `PotPosition` MDX components.
+- Produces: a published record resolved at `/sn/RLY26001` and `/sn/RLY26001/print`.
+
+- [x] **Step 1: Replace placeholder copy with finished demonstration copy**
+
+Set `publish: true`, retain the existing photo, and describe the instrument as a K7RHY-voiced Relay Lipstick demonstration build. Give each pickup, switch position, and pot state short practical language that helps a player find the instrument's voices.
+
+- [x] **Step 2: Validate the content model**
+
+Run: `npx vitest run lib/instruments components/instrument`
+
+Expected: all instrument validation, route, record-page, and case-card tests pass.
+
+- [x] **Step 3: Build the production route**
+
+Run: `npm run build`
+
+Expected: Content Collections accepts `RLY26001.mdx`, Next.js emits `/sn/[serial]` and `/sn/[serial]/print`, and sitemap generation completes.
+
+- [x] **Step 4: Review both rendered surfaces**
+
+Run: `npm run dev`
+
+Open `/sn/RLY26001`, then `/sn/RLY26001/print`. Confirm the web page retains normal site navigation, the case card remains one page, and the QR encodes the canonical record URL.
+
+- [x] **Step 5: Commit and push the sample**
+
+```bash
+git add content/instruments/RLY26001.mdx docs/superpowers/plans/2026-06-22-sample-instrument-record.md
+git commit -m "content: publish sample instrument record"
+git push
+```

--- a/docs/superpowers/specs/2026-06-19-instrument-records-design.md
+++ b/docs/superpowers/specs/2026-06-19-instrument-records-design.md
@@ -1,0 +1,218 @@
+# Serialized Instrument Records — Design Specification
+
+**Status:** Approved on 2026-06-19
+
+## Purpose
+
+K7RHY will publish a permanent record for each custom-built or modified/resold guitar. An owner can reach the record by typing the instrument serial number or scanning a QR code supplied with the guitar.
+
+The experience must do more than expose technical data. It should make the owner feel pride in a singular, cared-for instrument while remaining recognizably part of the existing K7RHY site. The printable case card serves primarily as a quick guide to the guitar's voices and how to access them. Its maker identity, serial number, component record, and permanent URL also provide quiet provenance that can follow the guitar through resale.
+
+## Serial Numbers and URLs
+
+Serial numbers use eight uppercase characters in the format `MMMYYNNN`:
+
+- `MMM`: a three-letter model, manufacturer, or platform code
+- `YY`: two-digit completion year
+- `NNN`: three-digit sequence number
+
+Example: `RLY26001`.
+
+The site will expose a simple editable code-to-description map. It has no categories or embedded taxonomy.
+
+```ts
+{
+    RLY: 'Relay',
+    FND: 'Fender',
+    TEL: 'Telecaster-style',
+}
+```
+
+The sole public route namespace is `/sn/`:
+
+- Canonical web record: `/sn/RLY26001`
+- Printable case card: `/sn/RLY26001/print`
+
+Lowercase serial URLs redirect to their uppercase canonical equivalent. Unknown records return the standard 404 page. Records are public and may be crawled and indexed, but they are not automatically listed in a public registry or site navigation.
+
+## Content Architecture
+
+Each instrument is a validated MDX document named for its serial number:
+
+```text
+content/instruments/RLY26001.mdx
+```
+
+The serial is derived from the filename and is not duplicated in frontmatter. A dedicated Content Collections schema validates instrument documents during the build. Both the web route and print route render the same validated record, preventing the two presentations from drifting apart.
+
+The frontmatter is limited to document-level identity and display metadata:
+
+```yaml
+---
+publish: false
+name: 'Relay Lipstick'
+completed: '2026-06-19'
+origin: 'Designed, built, and voiced by K7RHY Resonance Lab.'
+theme: 'An articulate, touch-sensitive instrument with a familiar core and one carefully shaped alternate identity.'
+images:
+    - src: '/images/instruments/RLY26001/front.jpg'
+      alt: 'Relay Lipstick RLY26001, full front view'
+related:
+    label: 'Explore the Relay Guitar family'
+    href: '/relay'
+---
+```
+
+The exact instrument photograph is required for the web record but does not appear on the printable case card. Additional photographs can appear in the ordinary MDX body.
+
+`publish: false` records return 404 in production. This permits authoring, validation, and local QR checking before publication.
+
+## Strict Instrument MDX Components
+
+Technical configuration is authored with compound MDX components rather than nested YAML. This makes the document readable and provides a single structured source for both web and print layouts.
+
+```mdx
+<InstrumentSpec>
+    <PickupConfiguration>
+        <Pickup position="bridge" type="humbucker" brand="GFS" model="VEH">
+            <PickupDetail label="Magnet">Alnico V</PickupDetail>
+            <PickupDetail label="Resistance">11.2 kΩ</PickupDetail>
+        </Pickup>
+
+        <Pickup position="middle" type="lipstick" brand="GFS" model="Pro-Tube" />
+
+        <Pickup position="neck" type="humbucker" brand="GFS" model="Professional Alnico II" />
+    </PickupConfiguration>
+
+    <ControlLayout>
+        <Selector label="Pickup selector" positions={3}>
+            <SelectorPosition voice="Bridge">Authority and attack</SelectorPosition>
+            <SelectorPosition voice="Bridge + Neck">Width and balance</SelectorPosition>
+            <SelectorPosition voice="Neck">Warmth and detail</SelectorPosition>
+        </Selector>
+
+        <Pot label="Master volume" mechanism="push-pull">
+            <PotPosition position="down" voice="Core voice">Controls overall output.</PotPosition>
+            <PotPosition position="up" voice="Lipstick Voice">Adds the middle lipstick and reshapes the bridge response.</PotPosition>
+        </Pot>
+
+        <Pot label="Master tone" mechanism="push-push">
+            <PotPosition position="down" voice="Open contour">Standard treble rolloff.</PotPosition>
+            <PotPosition position="up" voice="Focused contour">Tightens and focuses the response.</PotPosition>
+        </Pot>
+    </ControlLayout>
+</InstrumentSpec>
+```
+
+The component contract is strict:
+
+- `InstrumentSpec` requires exactly one `PickupConfiguration` and one `ControlLayout`.
+- Every pickup requires `position`, `type`, `brand`, and `model`.
+- `PickupDetail` entries are optional and hold useful electrical details such as magnet, resistance, or wiring.
+- A selector declares whether it has three or five positions.
+- `SelectorPosition` children are written in physical/display order. Their visible numbers are inferred from sequence and never authored manually.
+- The number of `SelectorPosition` children must match the selector's declared position count.
+- A `push-pull` or `push-push` pot requires exactly one `down` and one `up` state.
+- A standard pot requires one `normal` state.
+- Invalid or incomplete structures fail the build with an error that names the affected serial number and missing or invalid child. Components do not silently omit incomplete content.
+
+Ordinary MDX content follows the structured specification. It may describe the instrument's story, design intent, work performed on a modified guitar, full construction notes, and additional photographs. If an unusual later modification occurs, it can be recorded under a plain dated heading; there is no service-history schema or maintenance workflow.
+
+Ownership names and ownership history are out of scope. The record belongs to the instrument, which avoids privacy issues and supports uncomplicated resale.
+
+## Web Record Experience
+
+The instrument page is a variation on the existing site theme, not a separate visual identity.
+
+- Preserve the standard K7RHY site header, main navigation, mobile navigation, dark-mode behavior, and footer.
+- Use the site's Inter and JetBrains Mono fonts, slate surfaces, borders, radii, shadows, and restrained sky/emerald accent language.
+- Place the exact instrument photograph, name, serial, completion date, origin, and theme in a proud identity-led hero.
+- Present the print action near the instrument identity.
+- Prioritize the structured voice and control map in the main content.
+- Follow with pickup configuration and any supplied technical details.
+- Render the narrative MDX body below the structured specification.
+- Show an optional contextual related link before the standard footer. This supports product and Relay-platform discovery without making the ownership page feel like an advertisement.
+- Use the centralized Discord invitation from `config/site.ts` for owner questions.
+
+The record should feel archival and premium, but the differentiation comes from hierarchy and provenance rather than a new palette or type system.
+
+## Printable Case Card
+
+The `Print case card` action opens the dedicated print route and invokes the browser print dialog. A generated PDF pipeline is deliberately out of scope because it would introduce a second renderer and additional debugging burden.
+
+The primary paper target is portrait US Letter (8.5 × 11 inches). The layout must also scale safely to portrait A4 without spilling onto a second page.
+
+The card contains, in order of emphasis:
+
+1. A masthead containing the actual site logo from `public/images/k7rhy_logo.png` alongside the full brand name, `K7RHY Resonance Lab`
+2. Instrument name, serial number, and completion year
+3. Short theme/character statement
+4. Voice summary
+5. A large structured control map containing every automatically numbered selector position and both states of every switched pot
+6. Compact pickup configuration with brand and model details plus optional technical details when meaningful
+7. Brief origin information
+8. Permanent web URL, centralized Discord support, and a QR code for the canonical production URL
+
+The card contains no instrument photograph. Most of its area is devoted to reminding a player which voices exist and exactly how to reach them. Maker identity, the serial, completion date, exact components, and permanent web record establish provenance without labeling the card a certificate or making an explicit proof-of-authenticity claim.
+
+Print presentation uses the existing Inter and JetBrains Mono typography and K7RHY slate/sky visual language. It may be more editorial than the web page, but must remain visibly related to the site. Print CSS removes navigation and controls, suppresses web-only narrative content, preserves essential background graphics when enabled, and provides a high-contrast monochrome-safe result.
+
+## QR Codes and Centralized Links
+
+QR codes are generated from the canonical production URL:
+
+```text
+https://k7rhy.app/sn/RLY26001
+```
+
+No QR image is authored or stored per instrument. The web and print presentations derive it from the same serial record. Discord uses the single URL already defined in `config/site.ts`; changing that value updates every instrument record and card.
+
+## Failure Behavior
+
+- Invalid serial filenames fail content validation.
+- Unknown three-letter codes fail content validation.
+- Missing required frontmatter fails content validation.
+- Missing images fail the build.
+- Invalid compound MDX structures fail rendering during the build with instrument-specific messages.
+- Unknown routes return the standard 404 page.
+- Unpublished records return 404 in production.
+- The print route cannot exist independently of the web record.
+
+## Verification
+
+Automated tests will cover:
+
+- Serial parsing and model-code translation
+- Frontmatter and filename validation
+- Strict compound-component child requirements
+- Automatic selector numbering for three-way and five-way selectors
+- Standard, push-pull, and push-push pot-state validation and rendering
+- Published, unpublished, lowercase, and unknown route behavior
+- Consistent instrument information between web and print presentations
+- Canonical QR destination
+- Print-specific visibility rules
+
+Rendered verification will cover:
+
+- Standard header/footer discovery paths and the contextual related link
+- Responsive web layout and keyboard access
+- Existing light and dark themes
+- US Letter and A4 one-page print output
+- Monochrome legibility
+- Site logo and full brand name in the case-card masthead
+- No clipped control descriptions or accidental second page
+
+## Continuity and Scope Control
+
+The design spec is the durable source of truth. A separate implementation plan will use checkboxes, exact file paths, test commands, and commit checkpoints. A short `.remember/remember.md` handoff will record the current state and next action when work pauses.
+
+Out of scope for the first version:
+
+- Public instrument registry or browse page
+- Owner names or transfer history
+- Authentication or private access codes
+- Database or web-based record editor
+- Generated PDF downloads
+- Service-management or maintenance-history system
+- Separate visual brand for instrument records
+

--- a/lib/instruments/records.test.ts
+++ b/lib/instruments/records.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import type { InstrumentRecord } from '@/types/instrument';
+import { isInstrumentPublished } from './visibility';
+
+const record = { publish: false } as InstrumentRecord;
+
+describe('isInstrumentPublished', () => {
+    it('hides an unpublished record in production', () => {
+        expect(isInstrumentPublished(record, 'production')).toBe(false);
+    });
+
+    it('shows an unpublished record during development', () => {
+        expect(isInstrumentPublished(record, 'development')).toBe(true);
+    });
+
+    it('shows a published record in production', () => {
+        expect(isInstrumentPublished({ ...record, publish: true }, 'production')).toBe(true);
+    });
+});

--- a/lib/instruments/records.ts
+++ b/lib/instruments/records.ts
@@ -10,7 +10,3 @@ export function getInstrument(serial: string): InstrumentRecord | undefined {
 export function getInstrumentStaticParams(): Array<{ serial: string }> {
     return allInstruments.map((instrument) => ({ serial: instrument.serial }));
 }
-
-export function isInstrumentPublished(record: InstrumentRecord): boolean {
-    return process.env.NEXT_PUBLIC_ENVIRONMENT !== 'production' || record.publish;
-}

--- a/lib/instruments/records.ts
+++ b/lib/instruments/records.ts
@@ -1,0 +1,16 @@
+import { allInstruments } from 'content-collections';
+import type { InstrumentRecord } from '@/types/instrument';
+import { normalizeInstrumentSerial } from './serial';
+
+export function getInstrument(serial: string): InstrumentRecord | undefined {
+    const normalized = normalizeInstrumentSerial(serial);
+    return allInstruments.find((instrument) => instrument.serial === normalized) as InstrumentRecord | undefined;
+}
+
+export function getInstrumentStaticParams(): Array<{ serial: string }> {
+    return allInstruments.map((instrument) => ({ serial: instrument.serial }));
+}
+
+export function isInstrumentPublished(record: InstrumentRecord): boolean {
+    return process.env.NEXT_PUBLIC_ENVIRONMENT !== 'production' || record.publish;
+}

--- a/lib/instruments/route-resolution.test.ts
+++ b/lib/instruments/route-resolution.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { InstrumentRecord } from '@/types/instrument';
+import { resolveInstrumentRequest } from './route-resolution';
+
+const unpublished = { serial: 'RLY26001', publish: false } as InstrumentRecord;
+const lookup = (serial: string) => (serial === 'RLY26001' ? unpublished : undefined);
+
+describe('resolveInstrumentRequest', () => {
+    it('redirects lowercase serials', () => {
+        expect(resolveInstrumentRequest('rly26001', 'development', lookup)).toEqual({ kind: 'redirect', location: '/sn/RLY26001' });
+    });
+
+    it('returns not-found for an unknown serial', () => {
+        expect(resolveInstrumentRequest('RLY26999', 'development', lookup)).toEqual({ kind: 'not-found' });
+    });
+
+    it('returns not-found for an unpublished production record', () => {
+        expect(resolveInstrumentRequest('RLY26001', 'production', lookup)).toEqual({ kind: 'not-found' });
+    });
+
+    it('returns the record outside production', () => {
+        expect(resolveInstrumentRequest('RLY26001', 'development', lookup)).toEqual({ kind: 'record', record: unpublished });
+    });
+});

--- a/lib/instruments/route-resolution.ts
+++ b/lib/instruments/route-resolution.ts
@@ -1,0 +1,20 @@
+import type { InstrumentRecord } from '@/types/instrument';
+import { normalizeInstrumentSerial } from './serial';
+
+export type InstrumentRecordLookup = (serial: string) => InstrumentRecord | undefined;
+
+export type InstrumentRequestResolution =
+    | { kind: 'redirect'; location: string }
+    | { kind: 'not-found' }
+    | { kind: 'record'; record: InstrumentRecord };
+
+export function resolveInstrumentRequest(input: string, environment: string | undefined, lookup: InstrumentRecordLookup): InstrumentRequestResolution {
+    const serial = normalizeInstrumentSerial(input);
+
+    if (input !== serial) return { kind: 'redirect', location: `/sn/${serial}` };
+
+    const record = lookup(serial);
+    if (!record || (environment === 'production' && !record.publish)) return { kind: 'not-found' };
+
+    return { kind: 'record', record };
+}

--- a/lib/instruments/serial.test.ts
+++ b/lib/instruments/serial.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { instrumentPath, instrumentUrl, normalizeInstrumentSerial, parseInstrumentSerial } from './serial';
+
+describe('instrument serials', () => {
+    it('parses a known MMMYYNNN serial', () => {
+        expect(parseInstrumentSerial('RLY26001')).toEqual({
+            serial: 'RLY26001',
+            modelCode: 'RLY',
+            modelDescription: 'Relay',
+            year: 2026,
+            index: 1,
+        });
+    });
+
+    it('normalizes lowercase input before routing', () => {
+        expect(normalizeInstrumentSerial('rly26001')).toBe('RLY26001');
+    });
+
+    it.each(['RLY-26001', 'RLY2601', 'R1Y26001', 'RLY26ABC'])('rejects malformed serial %s', (serial) => {
+        expect(() => parseInstrumentSerial(serial)).toThrow(`Invalid instrument serial: ${serial}`);
+    });
+
+    it('rejects an unknown model code', () => {
+        expect(() => parseInstrumentSerial('ZZZ26001')).toThrow('Unknown instrument model code: ZZZ');
+    });
+
+    it('builds canonical paths and production URLs', () => {
+        expect(instrumentPath('rly26001')).toBe('/sn/RLY26001');
+        expect(instrumentUrl('RLY26001')).toBe('https://k7rhy.app/sn/RLY26001');
+    });
+});

--- a/lib/instruments/serial.ts
+++ b/lib/instruments/serial.ts
@@ -1,0 +1,40 @@
+import { INSTRUMENT_MODEL_CODES } from '@/config/instrument-model-codes';
+import type { InstrumentSerial } from '@/types/instrument';
+
+const SERIAL_PATTERN = /^([A-Z]{3})(\d{2})(\d{3})$/;
+
+export function normalizeInstrumentSerial(input: string): string {
+    return input.trim().toUpperCase();
+}
+
+export function parseInstrumentSerial(input: string): InstrumentSerial {
+    const serial = normalizeInstrumentSerial(input);
+    const match = SERIAL_PATTERN.exec(serial);
+
+    if (!match) {
+        throw new Error(`Invalid instrument serial: ${input}`);
+    }
+
+    const [, modelCode, yearPart, indexPart] = match;
+    const modelDescription = INSTRUMENT_MODEL_CODES[modelCode];
+
+    if (!modelDescription) {
+        throw new Error(`Unknown instrument model code: ${modelCode}`);
+    }
+
+    return {
+        serial,
+        modelCode,
+        modelDescription,
+        year: 2000 + Number(yearPart),
+        index: Number(indexPart),
+    };
+}
+
+export function instrumentPath(serial: string): string {
+    return `/sn/${parseInstrumentSerial(serial).serial}`;
+}
+
+export function instrumentUrl(serial: string): string {
+    return `https://k7rhy.app${instrumentPath(serial)}`;
+}

--- a/lib/instruments/validation.test.ts
+++ b/lib/instruments/validation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { InstrumentFrontmatter } from '@/types/instrument';
+import { validateInstrumentDocument } from './validation';
+
+const valid: InstrumentFrontmatter = {
+    publish: false,
+    name: 'Relay Lipstick',
+    completed: '2026-06-19',
+    origin: 'Designed, built, and voiced by K7RHY Resonance Lab.',
+    theme: 'Articulate and touch-sensitive.',
+    images: [{ src: '/images/products/guitars/rainbow-tele/front.jpeg', alt: 'RLY26001 front view' }],
+    related: { label: 'Explore Relay Guitar', href: '/relay' },
+    content: '<InstrumentSpec />',
+};
+
+describe('validateInstrumentDocument', () => {
+    it('derives serial data from the MDX path', () => {
+        expect(validateInstrumentDocument('RLY26001', valid)).toMatchObject({ serial: 'RLY26001', modelDescription: 'Relay' });
+    });
+
+    it('requires at least one exact-instrument image', () => {
+        expect(() => validateInstrumentDocument('RLY26001', { ...valid, images: [] })).toThrow('RLY26001 requires at least one instrument image');
+    });
+
+    it('requires a local absolute image path and useful alt text', () => {
+        expect(() => validateInstrumentDocument('RLY26001', { ...valid, images: [{ src: 'front.jpg', alt: '' }] })).toThrow('RLY26001 has an invalid instrument image');
+    });
+
+    it('rejects an image path that does not exist under public', () => {
+        expect(() => validateInstrumentDocument('RLY26001', { ...valid, images: [{ src: '/images/instruments/missing.jpg', alt: 'Missing image' }] })).toThrow('RLY26001 image does not exist: /images/instruments/missing.jpg');
+    });
+
+    it('requires the serial year to match the completion date', () => {
+        expect(() => validateInstrumentDocument('RLY26001', { ...valid, completed: '2025-12-31' })).toThrow('RLY26001 year does not match completion date 2025-12-31');
+    });
+});

--- a/lib/instruments/validation.ts
+++ b/lib/instruments/validation.ts
@@ -1,0 +1,30 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import type { InstrumentFrontmatter } from '@/types/instrument';
+import { parseInstrumentSerial } from './serial';
+
+export function validateInstrumentDocument(path: string, data: InstrumentFrontmatter) {
+    const serialData = parseInstrumentSerial(path);
+
+    if (data.images.length === 0) {
+        throw new Error(`${serialData.serial} requires at least one instrument image`);
+    }
+
+    const completedYear = Number(data.completed.slice(0, 4));
+    if (completedYear !== serialData.year) {
+        throw new Error(`${serialData.serial} year does not match completion date ${data.completed}`);
+    }
+
+    for (const image of data.images) {
+        if (!image.src.startsWith('/') || image.alt.trim().length === 0) {
+            throw new Error(`${serialData.serial} has an invalid instrument image`);
+        }
+
+        const absolutePath = join(process.cwd(), 'public', image.src.replace(/^\//, ''));
+        if (!existsSync(absolutePath)) {
+            throw new Error(`${serialData.serial} image does not exist: ${image.src}`);
+        }
+    }
+
+    return serialData;
+}

--- a/lib/instruments/visibility.ts
+++ b/lib/instruments/visibility.ts
@@ -1,0 +1,5 @@
+import type { InstrumentRecord } from '@/types/instrument';
+
+export function isInstrumentPublished(record: InstrumentRecord, environment = process.env.NODE_ENV): boolean {
+    return environment !== 'production' || record.publish;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
                 "next-sitemap": "^4.2.3",
                 "next-themes": "^0.4.6",
                 "punycode": "^2.3.1",
+                "qrcode.react": "^4.2.0",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0",
                 "react-hook-form": "^7.66.0",
@@ -14942,6 +14943,15 @@
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qrcode.react": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+            "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "next-sitemap": "^4.2.3",
         "next-themes": "^0.4.6",
         "punycode": "^2.3.1",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.66.0",

--- a/types/instrument.ts
+++ b/types/instrument.ts
@@ -1,0 +1,30 @@
+export interface InstrumentSerial {
+    serial: string;
+    modelCode: string;
+    modelDescription: string;
+    year: number;
+    index: number;
+}
+
+export interface InstrumentImage {
+    src: string;
+    alt: string;
+}
+
+export interface InstrumentRelatedLink {
+    label: string;
+    href: string;
+}
+
+export interface InstrumentFrontmatter {
+    publish: boolean;
+    name: string;
+    completed: string;
+    origin: string;
+    theme: string;
+    images: InstrumentImage[];
+    related?: InstrumentRelatedLink;
+    content: string;
+}
+
+export interface InstrumentRecord extends InstrumentFrontmatter, InstrumentSerial {}


### PR DESCRIPTION
## Summary
- add validated MDX instrument records addressed by compact serial numbers at `/sn/[serial]`
- add structured pickup, selector, and pot components for consistent control documentation
- add branded instrument detail pages and one-page printable case cards with QR and Discord access
- add editable model-code registry, authoring guidance, route handling, and print-layout coverage

## Verification
- `npx vitest run` — 28 files, 119 tests passed
- `npm run build` — production build and sitemap generation passed
- browser QA — desktop light/dark, 390px mobile, navigation, print route, QR destination, and Letter/A4 printable bounds