### PR TITLE
Add Relay electronics reference pages

### DIFF
--- a/config/relay-nav.ts
+++ b/config/relay-nav.ts
@@ -40,7 +40,15 @@ export const relayNav: RelayNav = {
     arc: {
         title: 'Relay Arc',
         status: 'lab',
-        sections: [],
+        sections: [
+            {
+                title: 'Electronics',
+                items: [
+                    { title: 'Parts List', slug: 'bom' },
+                    { title: 'Wiring Guide', slug: 'wiring' },
+                ],
+            },
+        ],
     },
     torch: {
         title: 'Relay Torch',

--- a/config/relay-nav.ts
+++ b/config/relay-nav.ts
@@ -39,7 +39,7 @@ export const relayNav: RelayNav = {
     },
     arc: {
         title: 'Relay Arc',
-        status: 'lab',
+        status: 'ready',
         sections: [
             {
                 title: 'Electronics',

--- a/content/relay/arc/bom.mdx
+++ b/content/relay/arc/bom.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Supply List'
+description: 'Everything you need to build a Relay Arc, with emphasis on the pickup set and control choices that preserve its open, spatial voice.'
+---
+
+Read this before you order parts. Arc depends less on unusual switching than on keeping the pickup set open, clear, and balanced around the middle voice.
+
+<DecisionNote variant="info" title="Arc lives or dies on separation.">
+    The middle Dream 180 is the center of this model, but the other two pickups matter just as much. If the bridge is too compressed or the neck is too dark, the combined positions lose the wide, airy quality that makes Arc worth building.
+</DecisionNote>
+
+## Hardware
+
+Use the shared [Relay components page](/relay/components?model=arc) for the common platform hardware: neck, bridge, ferrules, tuners, strings, jack, hookup wire, shielding, and the other body parts that do not change by voicing.
+
+## Pickups
+
+<BomSection>
+    <BomItem title="Neck Humbucker — GFS Vintage 59" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="arc-neck-pickup" fallback="$37.00" specific>
+        The neck needs to stay open and readable. A soft, dark neck pickup closes down positions 4 and 5 too much and pulls Arc away from its spatial clean behavior.
+    </BomItem>
+    <BomItem title="Middle Humbucker — GFS Dream 180" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="arc-middle-pickup" fallback="$45.00" specific>
+        This is the defining Arc pickup. It provides the chime and width that make position 3 and the combined positions feel separated instead of thick.
+    </BomItem>
+    <BomItem title="Bridge Filtertron-style Pickup — GFS Retrotron Liverpool" href="https://www.guitarfetish.com" source="Guitar Fetish" itemKey="arc-bridge-pickup" fallback="$45.00" specific>
+        Arc wants bridge clarity, not grind. The Liverpool keeps the attack articulate so position 1 stays bright and position 2 remains spacious instead of congested.
+    </BomItem>
+</BomSection>
+
+## Electronics
+
+<BomSection>
+    <BomItem title="Volume Pot (500k)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="arc-volume-pot" fallback="$8.00">
+        Standard 500k audio taper pot. No switching function is required on the volume control for Arc.
+    </BomItem>
+    <BomItem title="Tone Pot (500k push-pull)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="arc-tone-pot" fallback="$12.00">
+        A push-pull body keeps room for the Arc air contour. The published base harness below works as a standard tone circuit even if the contour branch is left unused.
+    </BomItem>
+    <BomItem title="Selector Switch (5-way blade)" href="https://amzn.to/[TODO]" source="Amazon" itemKey="arc-selector-switch" fallback="$10.00" specific>
+        Arc treats the middle pickup as a main destination, so this must be a 5-way blade rather than a 3-way toggle.
+    </BomItem>
+    <BomItem title="Tone Capacitor" href="https://amzn.to/3NEJ18n" source="Amazon" itemKey="tone-capacitor" fallback="$10.00" substitution="Cap value is still a tonal preference. Start with the reference value, then experiment only after the base harness is working." />
+</BomSection>
+

--- a/content/relay/arc/wiring.mdx
+++ b/content/relay/arc/wiring.mdx
@@ -1,53 +1,53 @@
 ---
 title: 'Wiring Guide'
-description: 'Bench-side wiring reference for the Relay Torch base harness.'
+description: 'Bench-side wiring reference for the Relay Arc base harness.'
 ---
 
-This is the bench-side reference for the Relay Torch harness. It gives you the selector map, pickup roles, labeled connection points, and the published base wiring without trying to turn the page into a full soldering class.
+This is the bench-side reference for the Relay Arc harness. It gives you the selector map, pickup locations, labeled connection points, and the published base wiring without turning into a full step-by-step soldering lesson.
 
-<DocAlert level="important" title="Build and prove the harness before installation">
-    Torch is easiest to debug while everything is loose on the bench. Wire the whole harness first, verify the selector map and output path, then mount it in the body.
+<DocAlert level="important" title="Build and test the harness before it goes into the body">
+    Arc is easier to debug on the bench than in the cavity. Wire the harness outside the body, verify every selector position, then install it once the signal path is proven.
 </DocAlert>
 
 ## Control Layout
 
 <ControlPositions switchLabel="5-Way Blade">
     <ControlPosition label="1" name="Bridge">
-        Bridge humbucker alone.
+        Retrotron Liverpool alone. The brightest, quickest Arc position.
     </ControlPosition>
     <ControlPosition label="2" name="Bridge + Middle">
-        Bridge humbucker and Mean 90 in parallel.
+        Liverpool and Dream 180 in parallel. Open attack with extra width.
     </ControlPosition>
     <ControlPosition label="3" name="Middle">
-        Mean 90 alone. This is the main Torch destination.
+        Dream 180 alone. The main Arc voice.
     </ControlPosition>
     <ControlPosition label="4" name="Neck + Middle">
-        Neck humbucker and Mean 90 in parallel.
+        Vintage 59 and Dream 180 in parallel. Wider and softer than position 3.
     </ControlPosition>
     <ControlPosition label="5" name="Neck">
-        Neck humbucker alone.
+        Vintage 59 alone. The warmest Arc position.
     </ControlPosition>
 </ControlPositions>
 
 **Volume** - Standard 500k audio taper.
 
-**Tone (push-pull)** - The published base harness uses the pot as a standard tone control. The push-pull switch lugs stay open until the Torch edge contour is finalized.
+**Tone (push-pull)** - The published base harness uses the pot as a standard tone control. The push-pull switch lugs remain open until the Arc air contour is finalized.
 
 ## Pickup Layout
 
-- Bridge: `GFS VEH Humbucker`, bridge cavity, strongest driven voice.
-- Middle: `GFS Mean 90`, middle cavity, main Torch voice.
-- Neck: `GFS Professional Series Alnico II Humbucker`, neck cavity, rounded supporting voice.
+- Bridge: `GFS Retrotron Liverpool`, bridge cavity, main bright voice.
+- Middle: `GFS Dream 180`, middle cavity, main Arc destination.
+- Neck: `GFS Vintage 59`, neck cavity, warm supporting voice.
 
 ## Reference Labels
 
 <ComponentLabels>
-    <ComponentLabel id="BP-H" component="Bridge Pickup (VEH)" wire="red" description="Hot output wire" />
-    <ComponentLabel id="BP-G" component="Bridge Pickup (VEH)" wire="black" description="Ground wire" />
-    <ComponentLabel id="MP-H" component="Middle Pickup (Mean 90)" wire="red" description="Hot output wire" />
-    <ComponentLabel id="MP-G" component="Middle Pickup (Mean 90)" wire="black" description="Ground wire" />
-    <ComponentLabel id="NP-H" component="Neck Pickup" wire="red" description="Hot output wire" />
-    <ComponentLabel id="NP-G" component="Neck Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="BP-H" component="Bridge Pickup (Retrotron Liverpool)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="BP-G" component="Bridge Pickup (Retrotron Liverpool)" wire="black" description="Ground wire" />
+    <ComponentLabel id="MP-H" component="Middle Pickup (Dream 180)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="MP-G" component="Middle Pickup (Dream 180)" wire="black" description="Ground wire" />
+    <ComponentLabel id="NP-H" component="Neck Pickup (Vintage 59)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="NP-G" component="Neck Pickup (Vintage 59)" wire="black" description="Ground wire" />
     <ComponentLabel id="SW-BP" component="5-Way Selector" description="Bridge input lug" />
     <ComponentLabel id="SW-MP" component="5-Way Selector" description="Middle input lug" />
     <ComponentLabel id="SW-NP" component="5-Way Selector" description="Neck input lug" />
@@ -90,22 +90,22 @@ This is the bench-side reference for the Relay Torch harness. It gives you the s
     <WireConnection from="J-SLV" to="GND" notes="Jack sleeve to ground bus" />
 </WiringConnections>
 
-Leave `TON-A1` through `TON-B3` open in this published revision. Those six switch lugs are reserved for the Torch edge contour and are intentionally unused in the base harness.
+Leave `TON-A1` through `TON-B3` open in this published revision. Those six switch lugs are reserved for the Arc air contour and are intentionally unused in the base harness.
 
 ## Build Outline
 
 <Proc title="Outline">
     <ProcStep text="Shield the cavity first">
-        Torch puts strong midrange right at the center of the selector map, so keep the control cavity quiet before any hardware goes in.
+        Apply copper foil before mounting any electronics. Arc is built for clean, spacious sounds, so noise control matters.
     </ProcStep>
-    <ProcStep text="Build the base 5-way harness on the bench">
-        Wire all three pickups to the selector, then complete the volume, standard tone branch, and output jack before you think about installation.
+    <ProcStep text="Wire the selector and pickups as the core harness">
+        Build the full 5-way signal path first: pickups to selector, selector to volume, volume to jack, and the standard tone branch.
     </ProcStep>
-    <ProcStep text="Keep the ground scheme simple">
-        Use one ground bus for shielding, pickup returns, pot backs, capacitor ground, and jack sleeve.
+    <ProcStep text="Finish the ground bus as a single system">
+        Tie all pickup grounds, pot backs, cavity shielding, capacitor return, and jack sleeve into one ground scheme instead of creating scattered ground islands.
     </ProcStep>
-    <ProcStep text="Install only after the selector map is proven">
-        Verify the 5-way positions and tap-test response before the harness goes into the body.
+    <ProcStep text="Bench-test before installation">
+        Verify every selector position with a meter and a tap test, then install the harness in the body only after the output jack reads and sounds correct.
     </ProcStep>
 </Proc>
 
@@ -113,12 +113,13 @@ Leave `TON-A1` through `TON-B3` open in this published revision. Those six switc
 
 <Proc title="Checks">
     <ProcStep text="Continuity">
-        In each selector position, `SW-OUT` should connect only to the expected pickup lug or lugs. Position 3 should isolate the Mean 90.
+        In each selector position, `SW-OUT` should connect only to the lug or lugs for that position. Position 3 should isolate the middle pickup.
     </ProcStep>
     <ProcStep text="Resistance">
-        With volume full up, measure between `J-TIP` and `J-SLV`. Expect roughly 11.2 kOhm in position 1, 8.7 kOhm in position 3, and 7.6 kOhm in position 5, with positions 2 and 4 reading lower because the pickups are in parallel.
+        With volume full up, measure between `J-TIP` and `J-SLV`. Expect roughly 9.5 kOhm in position 1, 9.0 kOhm in position 3, and 8.0 kOhm in position 5, with the combined positions reading lower because the pickups are in parallel.
     </ProcStep>
     <ProcStep text="Tap test">
-        Plug into an amp at low volume and tap each pickup with a metal screwdriver. Make sure the Mean 90 is isolated in position 3 and blended only in positions 2 and 4.
+        Plug into an amp at low volume and tap each pickup with a metal screwdriver. You should hear the expected pickup or pickup pair for every switch position.
     </ProcStep>
 </Proc>
+

--- a/content/relay/lipstick/wiring.mdx
+++ b/content/relay/lipstick/wiring.mdx
@@ -1,125 +1,125 @@
 ---
 title: 'Wiring Guide'
-description: 'Step-by-step wiring instructions for the Relay Lipstick.'
+description: 'Bench-side wiring reference for the published Relay Lipstick harness.'
 ---
 
-The Lipstick circuit has two layers. The 3-way toggle selects between the bridge humbucker, both humbuckers together, and the neck humbucker. The push-push volume adds the lipstick shaper on top of whichever humbucker position is selected, and simultaneously engages a partial coil split on the bridge with level compensation to keep the blend balanced.
+This is the bench-side reference for the published Relay Lipstick harness. It documents the core selector, volume, tone, output, and ground path clearly. The lipstick blend and contour switching remain more specialized than the other Relay models, so this page treats the published harness as a reference build rather than a beginner-proof recipe.
 
-<DocAlert level="important" title="Shield the cavity before installing components">
-    The lipstick pickup is sensitive to interference. Apply copper foil tape to all cavity walls and the floor first — doing it after assembly is much harder and the shielding is not optional.
+<DocAlert level="important" title="Build the core harness first">
+    On Lipstick, prove the humbucker selector path, the main volume/tone path, and the ground bus before you add the lipstick blend branch. Debugging everything at once is where this model gets frustrating.
 </DocAlert>
 
-## Component Labels
+## Control Layout
 
-Each connection point in this guide has a short label. Use the table below as a reference while wiring — the same labels appear on the component diagram.
+<ControlPositions switchLabel="3-Way Toggle">
+    <ControlPosition label="1" name="Bridge">
+        Bridge humbucker alone.
+    </ControlPosition>
+    <ControlPosition label="2" name="Bridge + Neck">
+        Bridge and neck humbuckers in parallel.
+    </ControlPosition>
+    <ControlPosition label="3" name="Neck">
+        Neck humbucker alone.
+    </ControlPosition>
+</ControlPositions>
 
-<DocImage
-    title="Relay Lipstick Wiring Diagram"
-    src="/images/relay/lipstick/wiring-diagram.png"
-    alt="Labeled wiring diagram showing all connection points for the Relay Lipstick"
-    triggerImageSize={300}
-    popupImageSize={1200}
-/>
+**Volume (push-push)** - Adds the lipstick branch on top of the selected humbucker voice.
+
+**Tone (push-pull)** - The published base harness uses the pot as a standard tone control. The push-pull switch lugs stay open here until the alternate contour branch is published separately.
+
+## Pickup Layout
+
+- Bridge: `GFS VEH Humbucker`, bridge cavity, strongest driven voice.
+- Middle: `GFS Pro-Tube Lipstick`, middle cavity, shaper layer added by the volume switch.
+- Neck: `GFS Classic II Alnico II Humbucker`, neck cavity, warmest core voice.
+
+## Reference Labels
 
 <ComponentLabels>
-    <ComponentLabel id="NP-H" component="Neck Pickup" wire="red" description="Hot output wire" />
-    <ComponentLabel id="NP-G" component="Neck Pickup" wire="black" description="Ground wire" />
-    <ComponentLabel id="NP-W" component="Neck Pickup" wire="white" description="Coil tap wire (for partial split)" />
-    <ComponentLabel id="BP-H" component="Bridge Pickup" wire="red" description="Hot output wire" />
-    <ComponentLabel id="BP-G" component="Bridge Pickup" wire="black" description="Ground wire" />
-    <ComponentLabel id="BP-W" component="Bridge Pickup" wire="white" description="Coil tap wire (for partial split)" />
-    <ComponentLabel id="LP-H" component="Lipstick Pickup" wire="red" description="Hot output wire" />
-    <ComponentLabel id="LP-G" component="Lipstick Pickup" wire="black" description="Ground wire" />
-    <ComponentLabel id="SW-B" component="3-Way Toggle" description="Bridge lug — receives bridge pickup hot" />
-    <ComponentLabel id="SW-N" component="3-Way Toggle" description="Neck lug — receives neck pickup hot" />
-    <ComponentLabel id="SW-C" component="3-Way Toggle" description="Common lug — output to volume pot" />
-    <ComponentLabel id="VOL-IN" component="Volume Pot (push-push)" description="Input lug — signal in from selector" />
-    <ComponentLabel id="VOL-W" component="Volume Pot (push-push)" description="Wiper lug — signal out to jack" />
-    <ComponentLabel id="VOL-B" component="Volume Pot (push-push)" description="Back of pot — connect to ground bus" />
-    <ComponentLabel id="VOL-PP" component="Volume Pot (push-push)" description="Push-push switch contacts — engages lipstick blend" />
-    <ComponentLabel id="TON-IN" component="Tone Pot (push-pull)" description="Input lug — tapped from VOL-IN" />
-    <ComponentLabel id="TON-W" component="Tone Pot (push-pull)" description="Wiper lug — to tone capacitor" />
-    <ComponentLabel id="TON-B" component="Tone Pot (push-pull)" description="Back of pot — connect to ground bus" />
-    <ComponentLabel id="TON-PP" component="Tone Pot (push-pull)" description="Push-pull switch contacts — engages alternate contour" />
-    <ComponentLabel id="CAP-H" component="Tone Capacitor" description="Hot leg — connects to TON-W" />
-    <ComponentLabel id="CAP-G" component="Tone Capacitor" description="Ground leg — connects to ground bus" />
-    <ComponentLabel id="J-TIP" component="Output Jack" description="Tip lug (hot signal to amp)" />
+    <ComponentLabel id="BP-H" component="Bridge Pickup (VEH)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="BP-G" component="Bridge Pickup (VEH)" wire="black" description="Ground wire" />
+    <ComponentLabel id="BP-W" component="Bridge Pickup (VEH)" wire="white" description="Series link / split lead used by the blend branch" />
+    <ComponentLabel id="LP-H" component="Middle Pickup (Lipstick)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="LP-G" component="Middle Pickup (Lipstick)" wire="black" description="Ground wire" />
+    <ComponentLabel id="NP-H" component="Neck Pickup (Classic II)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="NP-G" component="Neck Pickup (Classic II)" wire="black" description="Ground wire" />
+    <ComponentLabel id="NP-W" component="Neck Pickup (Classic II)" wire="white" description="Series link / split lead, grounded in the published harness" />
+    <ComponentLabel id="SW-B" component="3-Way Toggle" description="Bridge input lug" />
+    <ComponentLabel id="SW-N" component="3-Way Toggle" description="Neck input lug" />
+    <ComponentLabel id="SW-C" component="3-Way Toggle" description="Toggle common/output lug" />
+    <ComponentLabel id="VOL-IN" component="Volume Pot (push-push)" description="Input lug from toggle" />
+    <ComponentLabel id="VOL-W" component="Volume Pot (push-push)" description="Wiper/output lug to jack" />
+    <ComponentLabel id="VOL-B" component="Volume Pot (push-push)" description="Back of pot, tied to ground bus" />
+    <ComponentLabel id="VOL-A1" component="Volume Push-Push Switch" description="Blend switch pole A, lug 1 - reserved for the lipstick branch" />
+    <ComponentLabel id="VOL-A2" component="Volume Push-Push Switch" description="Blend switch pole A, lug 2 - reserved for the lipstick branch" />
+    <ComponentLabel id="VOL-A3" component="Volume Push-Push Switch" description="Blend switch pole A, lug 3 - reserved for the lipstick branch" />
+    <ComponentLabel id="VOL-B1" component="Volume Push-Push Switch" description="Blend switch pole B, lug 1 - reserved for the bridge partial-split branch" />
+    <ComponentLabel id="VOL-B2" component="Volume Push-Push Switch" description="Blend switch pole B, lug 2 - reserved for the bridge partial-split branch" />
+    <ComponentLabel id="VOL-B3" component="Volume Push-Push Switch" description="Blend switch pole B, lug 3 - reserved for the bridge partial-split branch" />
+    <ComponentLabel id="TON-IN" component="Tone Pot (push-pull)" description="Tone input lug, tapped from VOL-IN" />
+    <ComponentLabel id="TON-W" component="Tone Pot (push-pull)" description="Tone wiper lug to capacitor" />
+    <ComponentLabel id="TON-B" component="Tone Pot (push-pull)" description="Back of pot, tied to ground bus" />
+    <ComponentLabel id="TON-A1" component="Tone Push-Pull Switch" description="Pole A, lug 1 - leave open in this revision" />
+    <ComponentLabel id="TON-A2" component="Tone Push-Pull Switch" description="Pole A, lug 2 - leave open in this revision" />
+    <ComponentLabel id="TON-A3" component="Tone Push-Pull Switch" description="Pole A, lug 3 - leave open in this revision" />
+    <ComponentLabel id="TON-B1" component="Tone Push-Pull Switch" description="Pole B, lug 1 - leave open in this revision" />
+    <ComponentLabel id="TON-B2" component="Tone Push-Pull Switch" description="Pole B, lug 2 - leave open in this revision" />
+    <ComponentLabel id="TON-B3" component="Tone Push-Pull Switch" description="Pole B, lug 3 - leave open in this revision" />
+    <ComponentLabel id="CAP-H" component="Tone Capacitor" description="Hot leg from tone wiper" />
+    <ComponentLabel id="CAP-G" component="Tone Capacitor" description="Ground leg to ground bus" />
+    <ComponentLabel id="J-TIP" component="Output Jack" description="Tip lug (hot)" />
     <ComponentLabel id="J-SLV" component="Output Jack" description="Sleeve lug (ground)" />
-    <ComponentLabel id="GND" component="Ground Bus" description="Common ground — cavity foil, pot backs, pickup grounds, jack sleeve" />
+    <ComponentLabel id="GND" component="Ground Bus" description="Common ground point for pot backs, pickup grounds, shielding, and jack sleeve" />
 </ComponentLabels>
 
-## Connections
+## Wiring Map
 
 <WiringConnections>
-    <WireConnection from="NP-H" to="SW-N" notes="Neck pickup hot to neck lug of toggle" />
-    <WireConnection from="BP-H" to="SW-B" notes="Bridge pickup hot to bridge lug of toggle" />
+    <WireConnection from="BP-H" to="SW-B" notes="Bridge pickup hot to bridge toggle lug" />
+    <WireConnection from="NP-H" to="SW-N" notes="Neck pickup hot to neck toggle lug" />
     <WireConnection from="SW-C" to="VOL-IN" notes="Toggle output to volume input" />
-    <WireConnection from="VOL-IN" to="TON-IN" notes="Tap from volume input to tone input" />
-    <WireConnection from="VOL-W" to="J-TIP" notes="Volume wiper to jack tip" />
-    <WireConnection from="TON-W" to="CAP-H" notes="Tone wiper to capacitor" />
-    <WireConnection from="LP-H" to="VOL-PP" notes="Lipstick hot to push-push switch — see diagram for exact contact" />
-    <WireConnection from="BP-W" to="VOL-PP" notes="Bridge coil tap to push-push switch — partial split on engagement" />
-    <WireConnection from="TON-PP" to="[TODO]" notes="Push-pull alternate contour — wiring TBD from final circuit diagram" />
-    <WireConnection from="NP-G" to="GND" notes="" />
-    <WireConnection from="BP-G" to="GND" notes="" />
-    <WireConnection from="LP-G" to="GND" notes="" />
-    <WireConnection from="NP-W" to="GND" notes="Coil tap grounded when lipstick blend is off" />
-    <WireConnection from="VOL-B" to="GND" notes="" />
-    <WireConnection from="TON-B" to="GND" notes="" />
-    <WireConnection from="CAP-G" to="GND" notes="" />
-    <WireConnection from="J-SLV" to="GND" notes="" />
+    <WireConnection from="VOL-IN" to="TON-IN" notes="Tone feed tapped from volume input" />
+    <WireConnection from="VOL-W" to="J-TIP" notes="Volume output to jack tip" />
+    <WireConnection from="TON-W" to="CAP-H" notes="Tone wiper to capacitor hot leg" />
+    <WireConnection from="BP-G" to="GND" notes="Bridge pickup ground" />
+    <WireConnection from="LP-G" to="GND" notes="Lipstick ground" />
+    <WireConnection from="NP-G" to="GND" notes="Neck pickup ground" />
+    <WireConnection from="NP-W" to="GND" notes="Neck series link grounded in the published harness" />
+    <WireConnection from="VOL-B" to="GND" notes="Ground the volume pot body" />
+    <WireConnection from="TON-B" to="GND" notes="Ground the tone pot body" />
+    <WireConnection from="CAP-G" to="GND" notes="Capacitor return to ground" />
+    <WireConnection from="J-SLV" to="GND" notes="Jack sleeve to ground bus" />
 </WiringConnections>
 
-## Wiring Procedure
+The published core harness stops there. `VOL-A1` through `VOL-B3` are reserved for the lipstick blend and bridge partial-split branch, and `TON-A1` through `TON-B3` are reserved for the alternate contour branch. Those subcircuits are still bench-note territory rather than a finalized published lug map.
 
-<Proc title="Wiring Steps">
-    <ProcStep text="Shield the cavity">
-        Apply copper foil tape to all cavity walls and the floor. Overlap foil sections by at least 2mm for continuity. Solder a short jumper wire across any gap between sections that don't overlap. Connect the foil to the ground bus with a short wire soldered to the foil surface.
+## Build Outline
+
+<Proc title="Outline">
+    <ProcStep text="Shield the cavity first">
+        Lipstick is the most noise-sensitive Relay voicing. Treat shielding as part of the circuit, not an optional cleanup step.
     </ProcStep>
-    <ProcStep text="Pre-tin all solder points">
-        Apply a small dot of solder to every lug and pad before making any connections. Pre-tinning uses less heat on the components and gives cleaner joints.
+    <ProcStep text="Build and verify the humbucker core harness first">
+        Get the 3-way selector, main volume path, tone path, jack, and ground bus working before adding the lipstick branch.
     </ProcStep>
-    <ProcStep text="Wire the 3-way toggle">
-        Connect NP-H to SW-N and BP-H to SW-B. Run a wire from SW-C to VOL-IN. This is the main humbucker selector circuit.
+    <ProcStep text="Add the lipstick and split branch only after the core path passes tests">
+        That branch is where the interesting behavior lives, but it is also where mistakes compound fastest.
     </ProcStep>
-    <ProcStep text="Wire the volume and tone pots">
-        Connect VOL-IN to TON-IN (tap, not a through connection). Connect VOL-W to J-TIP. Connect TON-W to CAP-H and CAP-G to GND.
-    </ProcStep>
-    <ProcStep text="Wire the lipstick blend circuit">
-        [TODO: document the exact push-push switch wiring for the lipstick blend, including the coil tap connections on the bridge pickup and any level compensation components.]
-    </ProcStep>
-    <ProcStep text="Wire the push-pull tone contour">
-        [TODO: document the exact push-pull switch wiring for the alternate voicing contour.]
-    </ProcStep>
-    <ProcStep text="Connect the ground bus">
-        Connect NP-G, BP-G, LP-G, NP-W (when blend off), VOL-B, TON-B, CAP-G, and J-SLV all to GND. Ensure the cavity foil connects to this same ground point.
+    <ProcStep text="Install only after the base path and blend branch behave as expected on the bench">
+        Lipstick becomes much harder to debug once everything is inside the body.
     </ProcStep>
 </Proc>
 
-## Pre-Installation Test
+## Sanity Checks
 
-Test on the bench before the components go into the body.
-
-<Proc title="Bench Test">
-    <ProcStep text="Check toggle switch continuity">
-        Set your multimeter to continuity mode. Move the toggle to each of the three positions and verify continuity from SW-C to the expected lug (SW-B in position 1, both in position 2, SW-N in position 3). No continuity should exist between SW-B and SW-N directly.
+<Proc title="Checks">
+    <ProcStep text="Continuity">
+        In toggle positions 1, 2, and 3, `SW-C` should connect to the bridge lug, both lugs, and the neck lug respectively.
     </ProcStep>
-    <ProcStep text="Resistance test — verify signal paths">
-        Set your multimeter to resistance (Ω) mode. With volume at maximum, probe between J-TIP and J-SLV. Expected readings by toggle position:
-
-        - **Position 1** (Bridge only): ~11.2 kΩ
-        - **Position 2** (Bridge + Neck, parallel): ~4.5 kΩ
-        - **Position 3** (Neck only): ~7.6 kΩ
-
-        With the lipstick blend engaged (push-push), each reading drops — a parallel pickup path is added. Position 3 + blend should read ~3.4 kΩ (neck 7.6K ∥ lipstick 6.0K). Position 1 + blend will be lower than 11.2K but the exact value depends on the partial split configuration. Open (OL) means a broken connection in that path. A reading much higher than expected in position 2 (e.g. 18–19 kΩ) suggests the two pickups may be wired in series instead of parallel. Individual pickups can vary ±10% from the spec values above.
+    <ProcStep text="Resistance">
+        With volume full up, measure between `J-TIP` and `J-SLV`. Expect roughly 11.2 kOhm in position 1, about 4.5 kOhm in position 2, and about 7.6 kOhm in position 3 before the lipstick branch is added.
     </ProcStep>
-    <ProcStep text="Check for ground shorts on the signal path">
-        Probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short.
-    </ProcStep>
-    <ProcStep text="Test the push-push volume function">
-        With the blend engaged (push-push activated), verify that LP-H has a path to J-TIP. With it disengaged, verify that path is broken.
-    </ProcStep>
-    <ProcStep text="Tap test each pickup">
-        Plug a cable into J-TIP and into an amp at low volume. Tap each pickup's pole pieces with a metal screwdriver. Verify all three pickups are audible in the appropriate positions — humbuckers via the toggle, lipstick via the push-push blend.
+    <ProcStep text="Tap test">
+        Plug into an amp at low volume and verify that the bridge and neck humbuckers respond correctly through the 3-way selector before you add the lipstick branch.
     </ProcStep>
 </Proc>

--- a/content/relay/velvet/wiring.mdx
+++ b/content/relay/velvet/wiring.mdx
@@ -1,120 +1,124 @@
 ---
 title: 'Wiring Guide'
-description: 'Step-by-step wiring instructions for the Relay Velvet.'
+description: 'Bench-side wiring reference for the Relay Velvet base harness.'
 ---
 
-Velvet uses a standard 5-way HSH (humbucker-filtertron-humbucker) wiring scheme. The 5-way blade gives the Retrotron Nashville its own position (3) and two combined positions (2 and 4). The volume is a standard pot. The push-pull tone engages the Velvet focus contour.
+This is the bench-side reference for the Relay Velvet harness. It gives you the selector map, pickup roles, labeled connection points, and the published base wiring without forcing a blow-by-blow soldering tutorial.
 
-<DocAlert level="important" title="Shield the cavity before installing components">
-    Apply copper foil tape to all cavity walls and the floor before installing anything. The Retrotron Nashville is more sensitive to interference than a standard humbucker.
+<DocAlert level="important" title="Build and test the harness before installation">
+    Velvet rewards careful bench work. Wire the harness outside the body, verify the 5-way map and output path, then install it once the base circuit is quiet and correct.
 </DocAlert>
 
-## Component Labels
+## Control Layout
 
-Each connection point in this guide has a short label. Use the table below as a reference — the same labels appear on the component diagram.
+<ControlPositions switchLabel="5-Way Blade">
+    <ControlPosition label="1" name="Bridge">
+        Bridge humbucker alone.
+    </ControlPosition>
+    <ControlPosition label="2" name="Bridge + Middle">
+        Bridge humbucker and Retrotron Nashville in parallel.
+    </ControlPosition>
+    <ControlPosition label="3" name="Middle">
+        Retrotron Nashville alone. This is the main Velvet destination.
+    </ControlPosition>
+    <ControlPosition label="4" name="Neck + Middle">
+        Neck humbucker and Retrotron Nashville in parallel.
+    </ControlPosition>
+    <ControlPosition label="5" name="Neck">
+        Neck humbucker alone.
+    </ControlPosition>
+</ControlPositions>
 
-<DocImage
-    title="Relay Velvet Wiring Diagram"
-    src="/images/relay/velvet/wiring-diagram.png"
-    alt="Labeled wiring diagram showing all connection points for the Relay Velvet"
-    triggerImageSize={300}
-    popupImageSize={1200}
-/>
+**Volume** - Standard 500k audio taper.
+
+**Tone (push-pull)** - The published base harness uses the pot as a standard tone control. The push-pull switch lugs stay open until the Velvet focus contour is finalized.
+
+## Pickup Layout
+
+- Bridge: `GFS Professional Series Alnico II Humbucker`, bridge cavity, clearest rhythm voice.
+- Middle: `GFS Retrotron Nashville`, middle cavity, primary Velvet voice.
+- Neck: `GFS Professional Series Alnico II Humbucker`, neck cavity, warmest voice.
+
+## Reference Labels
 
 <ComponentLabels>
-    <ComponentLabel id="NP-H" component="Neck Pickup" wire="red" description="Hot output wire" />
-    <ComponentLabel id="NP-G" component="Neck Pickup" wire="black" description="Ground wire" />
-    <ComponentLabel id="MP-H" component="Middle Pickup (Retrotron)" wire="red" description="Hot output wire" />
-    <ComponentLabel id="MP-G" component="Middle Pickup (Retrotron)" wire="black" description="Ground wire" />
     <ComponentLabel id="BP-H" component="Bridge Pickup" wire="red" description="Hot output wire" />
     <ComponentLabel id="BP-G" component="Bridge Pickup" wire="black" description="Ground wire" />
-    <ComponentLabel id="SW-BP" component="5-Way Selector" description="Bridge pickup input lug — see diagram for physical lug number" />
-    <ComponentLabel id="SW-MP" component="5-Way Selector" description="Middle pickup input lug — see diagram for physical lug number" />
-    <ComponentLabel id="SW-NP" component="5-Way Selector" description="Neck pickup input lug — see diagram for physical lug number" />
-    <ComponentLabel id="SW-OUT" component="5-Way Selector" description="Output lug (common) — signal to volume pot" />
-    <ComponentLabel id="VOL-IN" component="Volume Pot (500k)" description="Input lug — signal in from selector" />
-    <ComponentLabel id="VOL-W" component="Volume Pot (500k)" description="Wiper lug — signal out to jack" />
-    <ComponentLabel id="VOL-B" component="Volume Pot (500k)" description="Back of pot — connect to ground bus" />
-    <ComponentLabel id="TON-IN" component="Tone Pot (push-pull)" description="Input lug — tapped from VOL-IN" />
-    <ComponentLabel id="TON-W" component="Tone Pot (push-pull)" description="Wiper lug — to tone capacitor" />
-    <ComponentLabel id="TON-B" component="Tone Pot (push-pull)" description="Back of pot — connect to ground bus" />
-    <ComponentLabel id="TON-PP" component="Tone Pot (push-pull)" description="Push-pull switch contacts — engages focus contour" />
-    <ComponentLabel id="CAP-H" component="Tone Capacitor" description="Hot leg — connects to TON-W" />
-    <ComponentLabel id="CAP-G" component="Tone Capacitor" description="Ground leg — connects to ground bus" />
-    <ComponentLabel id="J-TIP" component="Output Jack" description="Tip lug (hot signal to amp)" />
+    <ComponentLabel id="MP-H" component="Middle Pickup (Retrotron Nashville)" wire="red" description="Hot output wire" />
+    <ComponentLabel id="MP-G" component="Middle Pickup (Retrotron Nashville)" wire="black" description="Ground wire" />
+    <ComponentLabel id="NP-H" component="Neck Pickup" wire="red" description="Hot output wire" />
+    <ComponentLabel id="NP-G" component="Neck Pickup" wire="black" description="Ground wire" />
+    <ComponentLabel id="SW-BP" component="5-Way Selector" description="Bridge input lug" />
+    <ComponentLabel id="SW-MP" component="5-Way Selector" description="Middle input lug" />
+    <ComponentLabel id="SW-NP" component="5-Way Selector" description="Neck input lug" />
+    <ComponentLabel id="SW-OUT" component="5-Way Selector" description="Selector common/output lug" />
+    <ComponentLabel id="VOL-IN" component="Volume Pot (500k)" description="Input lug from selector" />
+    <ComponentLabel id="VOL-W" component="Volume Pot (500k)" description="Wiper/output lug to jack" />
+    <ComponentLabel id="VOL-B" component="Volume Pot (500k)" description="Back of pot, tied to ground bus" />
+    <ComponentLabel id="TON-IN" component="Tone Pot (500k push-pull)" description="Tone input lug, tapped from VOL-IN" />
+    <ComponentLabel id="TON-W" component="Tone Pot (500k push-pull)" description="Tone wiper lug to capacitor" />
+    <ComponentLabel id="TON-B" component="Tone Pot (500k push-pull)" description="Back of pot, tied to ground bus" />
+    <ComponentLabel id="TON-A1" component="Tone Push-Pull Switch" description="Pole A, lug 1 - leave open in this revision" />
+    <ComponentLabel id="TON-A2" component="Tone Push-Pull Switch" description="Pole A, lug 2 - leave open in this revision" />
+    <ComponentLabel id="TON-A3" component="Tone Push-Pull Switch" description="Pole A, lug 3 - leave open in this revision" />
+    <ComponentLabel id="TON-B1" component="Tone Push-Pull Switch" description="Pole B, lug 1 - leave open in this revision" />
+    <ComponentLabel id="TON-B2" component="Tone Push-Pull Switch" description="Pole B, lug 2 - leave open in this revision" />
+    <ComponentLabel id="TON-B3" component="Tone Push-Pull Switch" description="Pole B, lug 3 - leave open in this revision" />
+    <ComponentLabel id="CAP-H" component="Tone Capacitor" description="Hot leg from tone wiper" />
+    <ComponentLabel id="CAP-G" component="Tone Capacitor" description="Ground leg to ground bus" />
+    <ComponentLabel id="J-TIP" component="Output Jack" description="Tip lug (hot)" />
     <ComponentLabel id="J-SLV" component="Output Jack" description="Sleeve lug (ground)" />
-    <ComponentLabel id="GND" component="Ground Bus" description="Common ground — cavity foil, pot backs, pickup grounds, jack sleeve" />
+    <ComponentLabel id="GND" component="Ground Bus" description="Common ground point for pot backs, pickup grounds, shielding, and jack sleeve" />
 </ComponentLabels>
 
-## Connections
+## Wiring Map
 
 <WiringConnections>
-    <WireConnection from="BP-H" to="SW-BP" notes="Bridge pickup hot to switch bridge lug" />
-    <WireConnection from="MP-H" to="SW-MP" notes="Middle pickup hot to switch middle lug" />
-    <WireConnection from="NP-H" to="SW-NP" notes="Neck pickup hot to switch neck lug" />
-    <WireConnection from="SW-OUT" to="VOL-IN" notes="Switch output to volume input" />
-    <WireConnection from="VOL-IN" to="TON-IN" notes="Tap from volume input to tone input" />
-    <WireConnection from="VOL-W" to="J-TIP" notes="Volume wiper to jack tip" />
-    <WireConnection from="TON-W" to="CAP-H" notes="Tone wiper to capacitor" />
-    <WireConnection from="TON-PP" to="[TODO]" notes="Push-pull focus contour — wiring TBD from final circuit diagram" />
-    <WireConnection from="BP-G" to="GND" notes="" />
-    <WireConnection from="MP-G" to="GND" notes="" />
-    <WireConnection from="NP-G" to="GND" notes="" />
-    <WireConnection from="VOL-B" to="GND" notes="" />
-    <WireConnection from="TON-B" to="GND" notes="" />
-    <WireConnection from="CAP-G" to="GND" notes="" />
-    <WireConnection from="J-SLV" to="GND" notes="" />
+    <WireConnection from="BP-H" to="SW-BP" notes="Bridge pickup hot to bridge selector lug" />
+    <WireConnection from="MP-H" to="SW-MP" notes="Middle pickup hot to middle selector lug" />
+    <WireConnection from="NP-H" to="SW-NP" notes="Neck pickup hot to neck selector lug" />
+    <WireConnection from="SW-OUT" to="VOL-IN" notes="Selector output to volume input" />
+    <WireConnection from="VOL-IN" to="TON-IN" notes="Tone feed tapped from volume input" />
+    <WireConnection from="VOL-W" to="J-TIP" notes="Volume output to jack tip" />
+    <WireConnection from="TON-W" to="CAP-H" notes="Tone wiper to capacitor hot leg" />
+    <WireConnection from="BP-G" to="GND" notes="Bridge pickup ground" />
+    <WireConnection from="MP-G" to="GND" notes="Middle pickup ground" />
+    <WireConnection from="NP-G" to="GND" notes="Neck pickup ground" />
+    <WireConnection from="VOL-B" to="GND" notes="Ground the volume pot body" />
+    <WireConnection from="TON-B" to="GND" notes="Ground the tone pot body" />
+    <WireConnection from="CAP-G" to="GND" notes="Capacitor return to ground" />
+    <WireConnection from="J-SLV" to="GND" notes="Jack sleeve to ground bus" />
 </WiringConnections>
 
-## Wiring Procedure
+Leave `TON-A1` through `TON-B3` open in this published revision. Those six switch lugs are reserved for the Velvet focus contour and are intentionally unused in the base harness.
 
-<Proc title="Wiring Steps">
-    <ProcStep text="Shield the cavity">
-        Apply copper foil tape to all cavity walls and the floor. Overlap foil sections by at least 2mm for continuity. Solder a short jumper wire across any gap between sections that don't overlap. Connect the foil to the ground bus with a short wire.
+## Build Outline
+
+<Proc title="Outline">
+    <ProcStep text="Shield the cavity first">
+        Velvet is meant to stay exposed and clean, so start with shielding before you mount anything.
     </ProcStep>
-    <ProcStep text="Pre-tin all solder points">
-        Apply a small dot of solder to every lug and pad before making any connections. Pre-tinning uses less heat on the components and gives cleaner joints.
+    <ProcStep text="Build the full 5-way base harness on the bench">
+        Wire the pickups to the selector, the selector to the volume pot, the tone branch from `VOL-IN`, and the jack from `VOL-W`.
     </ProcStep>
-    <ProcStep text="Wire the 5-way selector">
-        Connect BP-H to SW-BP, MP-H to SW-MP, and NP-H to SW-NP. The exact physical lug numbers depend on the switch brand — refer to the component diagram. Run a wire from SW-OUT to VOL-IN.
+    <ProcStep text="Run one clean ground scheme">
+        Tie shielding, pickup grounds, pot backs, capacitor return, and jack sleeve into one ground bus.
     </ProcStep>
-    <ProcStep text="Wire the volume and tone pots">
-        Tap a wire from VOL-IN to TON-IN. Connect VOL-W to J-TIP. Connect TON-W to CAP-H and CAP-G to GND.
-    </ProcStep>
-    <ProcStep text="Wire the push-pull focus contour">
-        [TODO: document the exact push-pull switch wiring for the Velvet focus contour.]
-    </ProcStep>
-    <ProcStep text="Connect the ground bus">
-        Connect BP-G, MP-G, NP-G, VOL-B, TON-B, CAP-G, and J-SLV all to GND. Ensure the cavity foil connects to this same point.
+    <ProcStep text="Install only after the harness passes a meter check and tap test">
+        The cavity is the wrong place to discover a bad selector joint.
     </ProcStep>
 </Proc>
 
-## Pre-Installation Test
+## Sanity Checks
 
-Test on the bench before the components go into the body.
-
-<Proc title="Bench Test">
-    <ProcStep text="Check selector switch continuity">
-        Set your multimeter to continuity mode. Move the selector to each of the five positions and verify continuity from SW-OUT to the expected input lug. Position 3 (center) should connect to SW-MP only. Positions 2 and 4 should show continuity to SW-MP and to one adjacent lug.
+<Proc title="Checks">
+    <ProcStep text="Continuity">
+        In each selector position, `SW-OUT` should connect only to the expected pickup lug or lugs. Position 3 should connect only to the middle pickup.
     </ProcStep>
-    <ProcStep text="Resistance test — verify signal paths">
-        Set your multimeter to resistance (Ω) mode. With volume at maximum, probe between J-TIP and J-SLV. Expected readings by selector position:
-
-        - **Position 1** (Bridge only): ~8.6 kΩ
-        - **Position 2** (Bridge + Middle, parallel): ~4.1 kΩ
-        - **Position 3** (Middle only): ~8.0 kΩ
-        - **Position 4** (Neck + Middle, parallel): ~3.9 kΩ
-        - **Position 5** (Neck only): ~7.6 kΩ
-
-        Open (OL) means a broken connection in that path. A reading much higher than expected in position 2 or 4 (e.g. 16–17 kΩ) suggests the two pickups may be wired in series instead of parallel. Individual pickups can vary ±10% from the spec values above.
+    <ProcStep text="Resistance">
+        With volume full up, measure between `J-TIP` and `J-SLV`. Expect roughly 8.6 kOhm in position 1, 8.0 kOhm in position 3, and 7.6 kOhm in position 5, with positions 2 and 4 reading lower because the pickups are in parallel.
     </ProcStep>
-    <ProcStep text="Check for ground shorts on the signal path">
-        Probe between J-TIP and GND. You should get no continuity in any switch position. Any reading here is an unintentional short.
-    </ProcStep>
-    <ProcStep text="Tap test each pickup">
-        Plug a cable into J-TIP and into an amp at low volume. Tap each pickup's pole pieces with a metal screwdriver. Move the selector through all five positions and verify the correct pickup responds in each position — Retrotron Nashville in position 3, bridge in position 1, neck in position 5.
-    </ProcStep>
-    <ProcStep text="Test the push-pull tone contour">
-        Pull the tone knob up and verify the contour engages. The character change should be audible when tapping pickup poles. Push it back down and verify it returns to the standard tone response.
+    <ProcStep text="Tap test">
+        Plug into an amp at low volume and tap each pickup with a metal screwdriver. Make sure the Retrotron Nashville is isolated in position 3 and blended only in positions 2 and 4.
     </ProcStep>
 </Proc>


### PR DESCRIPTION
## Summary
- add Arc electronics BOM and wiring reference pages
- rewrite the Lipstick, Velvet, and Torch wiring pages as concise bench-side control and lug maps
- wire the new Arc pages into the Relay navigation

## Verification
- `npm run build`