### PR TITLE
Fix RelayProcessOverview grid layout for 5 build stages

### DIFF
--- a/components/relay/relay-process-overview.test.tsx
+++ b/components/relay/relay-process-overview.test.tsx
@@ -58,4 +58,13 @@ describe('RelayProcessOverview', () => {
         expect(screen.getByText(/open wiring guide/i)).toBeInTheDocument();
         expect(screen.getByText(/follow progress/i)).toBeInTheDocument();
     });
+
+    it('spans the odd fifth card (Assembly) across the full row so the grid has no dangling gap', () => {
+        render(<RelayProcessOverview />);
+        const assemblyLink = screen.getByRole('link', { name: /^5\s*assembly/i });
+
+        expect(assemblyLink).toHaveClass('md:col-span-2');
+        const bodyLink = screen.getByRole('link', { name: /^1\s*body/i });
+        expect(bodyLink).not.toHaveClass('md:col-span-2');
+    });
 });

--- a/components/relay/relay-process-overview.tsx
+++ b/components/relay/relay-process-overview.tsx
@@ -14,13 +14,13 @@ function StageStatusBadge({ status }: { status: RelayStageStatus }) {
     return <span className="shrink-0 rounded-full border border-slate-500/30 bg-slate-500/10 px-2 py-0.5 text-xs font-medium text-slate-600 dark:text-slate-400">Planned</span>;
 }
 
-function RelayProcessCard({ stage }: { stage: RelayBuildStage }) {
+function RelayProcessCard({ stage, className }: { stage: RelayBuildStage; className?: string }) {
     const linkProps = stage.isDiscord ? { target: '_blank', rel: 'noopener noreferrer' as const } : {};
 
     const ctaLabel = stage.status === 'live' ? `Open ${stage.title.toLowerCase()} guide →` : stage.status === 'in-progress' ? 'Follow progress →' : 'Coming soon →';
 
     return (
-        <Link href={stage.href} {...linkProps} className="group block h-full">
+        <Link href={stage.href} {...linkProps} className={cn('group block h-full', className)}>
             <div className={cn('flex h-full flex-col gap-3 rounded-xl border border-border/60 bg-card p-5 shadow-sm transition-all', 'group-hover:border-sky-500 group-hover:shadow-[0_2px_10px_rgba(14,165,233,0.18)]')}>
                 <div className="flex items-start justify-between gap-2">
                     <div className="flex items-center gap-2">
@@ -37,11 +37,12 @@ function RelayProcessCard({ stage }: { stage: RelayBuildStage }) {
 }
 
 export function RelayProcessOverview() {
+    const { stages } = relayBuildProcess;
+    const isLastRowAlone = stages.length % 2 === 1;
+
     return (
-        <div className="my-6 grid grid-cols-1 gap-4 md:grid-cols-3">
-            {relayBuildProcess.stages.map((stage) => (
-                <RelayProcessCard key={stage.slug} stage={stage} />
-            ))}
+        <div className="my-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+            {stages.map((stage, index) => <RelayProcessCard key={stage.slug} stage={stage} className={isLastRowAlone && index === stages.length - 1 ? 'md:col-span-2' : undefined} />)}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- The build-flow restructure (PR #82) added Parts and Wiring stages, bringing `relayBuildProcess.stages` to 5. The existing `md:grid-cols-3` grid split them 3+2, leaving a dangling gap in the last row.
- Switched `RelayProcessOverview` to a 2-column grid and made the trailing odd card (Assembly) span the full row width, so it reads as an intentional closing step rather than a layout gap.
- Verified visually at mobile/tablet/desktop widths in the dev server; card text is comfortably readable at 2 columns (the container is ~800px wide, so 5 columns would have cramped the paragraph copy).

## Test plan
- [x] `npx vitest run components/relay/relay-process-overview.test.tsx` — 5/5 pass (added a test asserting the full-width span on the odd last card)
- [x] `npx vitest run` — 156/156 pass
- [x] `npm run lint` — clean
- [x] Manually checked `/relay` at mobile, tablet, and desktop viewports in the browser preview