### PR TITLE
Refine Relay voice tabs and wiring copy

### DIFF
--- a/components/relay/relay-voicing-tabs.test.tsx
+++ b/components/relay/relay-voicing-tabs.test.tsx
@@ -10,10 +10,26 @@ const voicings = [
 ];
 
 describe('RelayVoicingTabs', () => {
+    it('frames the tabs with a voice-selection instruction and scroll cue', () => {
+        render(<RelayVoicingTabs voicings={[{ slug: 'lipstick', name: 'Relay Lipstick', genres: 'Blues · Rock' }]} activeSlug="lipstick" basePath="/relay/parts" />);
+        expect(screen.getByText('Select a voice')).toBeInTheDocument();
+        expect(screen.getByText('Scroll')).toBeInTheDocument();
+        expect(screen.getByRole('tablist')).toHaveAttribute('aria-label', 'Select a Relay voice');
+    });
+
+    it('does not show the scroll cue for compact tabs without genre details', () => {
+        render(<RelayVoicingTabs voicings={voicings} activeSlug="lipstick" basePath="/relay/wiring" />);
+        expect(screen.getByText('Select a voice')).toBeInTheDocument();
+        expect(screen.queryByText('Scroll')).not.toBeInTheDocument();
+    });
+
     it('renders a link per voicing pointing at basePath with the voicing param', () => {
         render(<RelayVoicingTabs voicings={voicings} activeSlug="lipstick" basePath="/relay/parts" />);
         expect(screen.getByRole('tab', { name: 'Relay Lipstick' })).toHaveAttribute('href', '/relay/parts?voicing=lipstick');
         expect(screen.getByRole('tab', { name: 'Relay Velvet' })).toHaveAttribute('href', '/relay/parts?voicing=velvet');
+        expect(screen.getByText('Lipstick')).toBeInTheDocument();
+        expect(screen.getByText('Velvet')).toBeInTheDocument();
+        expect(screen.queryByText('Relay Lipstick')).not.toBeInTheDocument();
     });
 
     it('marks the active voicing with aria-current', () => {
@@ -22,10 +38,21 @@ describe('RelayVoicingTabs', () => {
         expect(screen.getByRole('tab', { name: 'Relay Lipstick' })).not.toHaveAttribute('aria-current');
     });
 
+    it('keeps the tab list on one horizontally scrollable row', () => {
+        render(<RelayVoicingTabs voicings={voicings} activeSlug="lipstick" basePath="/relay/parts" />);
+        const tablist = screen.getByRole('tablist');
+        expect(tablist.className).toMatch(/overflow-x-auto/);
+        expect(tablist.className).toMatch(/flex-nowrap/);
+        expect(screen.getByRole('tab', { name: 'Relay Lipstick' }).className).toMatch(/bg-background/);
+        expect(screen.getByRole('tab', { name: 'Relay Lipstick' }).className).toMatch(/rounded-t-md/);
+        expect(screen.getByRole('tab', { name: 'Relay Velvet' }).className).toMatch(/shrink-0/);
+        expect(screen.getByRole('tab', { name: 'Relay Velvet' }).className).toMatch(/border-border/);
+    });
+
     it('renders the name in a bolder line above a smaller genres line when genres are provided', () => {
         render(<RelayVoicingTabs voicings={[{ slug: 'lipstick', name: 'Relay Lipstick', genres: 'Blues · Rock' }]} activeSlug="lipstick" basePath="/relay/parts" />);
         const tab = screen.getByRole('tab', { name: 'Relay Lipstick' });
-        const name = within(tab).getByText('Relay Lipstick');
+        const name = within(tab).getByText('Lipstick');
         const genres = within(tab).getByText('Blues · Rock');
         expect(name.className).toMatch(/font-semibold/);
         expect(genres.className).toMatch(/text-xs/);

--- a/components/relay/relay-voicing-tabs.tsx
+++ b/components/relay/relay-voicing-tabs.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface RelayVoicingTab {
@@ -8,23 +9,43 @@ export interface RelayVoicingTab {
     genres?: string;
 }
 
+function getVoicingTabLabel(name: string): string {
+    return name.replace(/^Relay\s+/, '');
+}
+
 /** A horizontal tab bar of voicing links. The page resolves the active voicing server-side and renders that voicing's content below this bar; each tab is a `?voicing=` link that swaps the content via RSC navigation without scrolling. */
 export function RelayVoicingTabs({ voicings, activeSlug, basePath }: { voicings: RelayVoicingTab[]; activeSlug: string; basePath: string }) {
+    const showScrollCue = voicings.some((voicing) => voicing.genres);
+
     return (
-        <div role="tablist" className="mb-6 flex flex-wrap gap-1 border-b">
-            {voicings.map((voicing) => {
-                const isActive = voicing.slug === activeSlug;
-                return (
-                    <Link key={voicing.slug} href={`${basePath}?voicing=${voicing.slug}`} scroll={false} role="tab" aria-current={isActive ? 'page' : undefined} aria-selected={isActive} className={cn('-mb-px flex flex-col items-start gap-0.5 border-b-2 px-3 py-2 transition-colors', isActive ? 'border-sky-500 text-foreground' : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground')}>
-                        <span className="text-sm font-semibold">{voicing.name}</span>
-                        {voicing.genres && (
-                            <span aria-hidden="true" className="text-xs font-normal text-muted-foreground">
-                                {voicing.genres}
-                            </span>
-                        )}
-                    </Link>
-                );
-            })}
+        <div className="mb-6">
+            <div className="mb-2 flex items-center justify-between gap-3">
+                <p className="text-sm font-semibold text-foreground">Select a voice</p>
+            </div>
+            <div className="relative">
+                <div role="tablist" aria-label="Select a Relay voice" className={cn('flex flex-nowrap gap-1 overflow-x-auto border-b', showScrollCue && 'pr-20')}>
+                    {voicings.map((voicing) => {
+                        const isActive = voicing.slug === activeSlug;
+                        const label = getVoicingTabLabel(voicing.name);
+                        return (
+                            <Link key={voicing.slug} href={`${basePath}?voicing=${voicing.slug}`} scroll={false} role="tab" aria-label={voicing.name} aria-current={isActive ? 'page' : undefined} aria-selected={isActive} className={cn('-mb-px flex shrink-0 flex-col items-start gap-0.5 rounded-t-md border px-3 py-2 transition-colors', isActive ? 'border-sky-500 border-b-background bg-background text-foreground' : 'border-border bg-muted/30 text-muted-foreground hover:border-sky-300 hover:bg-background hover:text-foreground')}>
+                                <span className="text-sm font-semibold">{label}</span>
+                                {voicing.genres && (
+                                    <span aria-hidden="true" className="whitespace-nowrap text-xs font-normal text-muted-foreground">
+                                        {voicing.genres}
+                                    </span>
+                                )}
+                            </Link>
+                        );
+                    })}
+                </div>
+                {showScrollCue && (
+                    <div aria-hidden="true" className="pointer-events-none absolute inset-y-0 right-0 flex items-center gap-1 bg-gradient-to-l from-background via-background/95 to-transparent pl-8 pr-1 text-[11px] font-semibold uppercase text-muted-foreground">
+                        <span>Scroll</span>
+                        <ArrowRight className="h-3.5 w-3.5" />
+                    </div>
+                )}
+            </div>
         </div>
     );
 }

--- a/content/relay/assembly/index.mdx
+++ b/content/relay/assembly/index.mdx
@@ -7,7 +7,7 @@ By the time you reach assembly you've printed and finished the body, chosen your
 
 ## What you can do today
 
-The wiring guides are complete for every released voicing — build and prove the harness on the bench before it goes anywhere near the body. Everything downstream of that is in development.
+The wiring guides are complete for every released voicing. Everything downstream of that is in development.
 
 ## What's coming
 

--- a/content/relay/wiring/arc.mdx
+++ b/content/relay/wiring/arc.mdx
@@ -5,10 +5,6 @@ description: 'Bench-side wiring reference for the Relay Arc base harness.'
 
 This is the bench-side reference for the Relay Arc harness. It gives you the selector map, pickup locations, labeled connection points, and the published base wiring without turning into a full step-by-step soldering lesson.
 
-<DocAlert level="important" title="Build and test the harness before it goes into the body">
-    Arc is easier to debug on the bench than in the cavity. Wire the harness outside the body, verify every selector position, then install it once the signal path is proven.
-</DocAlert>
-
 ## Control Layout
 
 <ControlPositions switchLabel="5-Way Blade">
@@ -122,4 +118,3 @@ Leave `TON-A1` through `TON-B3` open in this published revision. Those six switc
         Plug into an amp at low volume and tap each pickup with a metal screwdriver. You should hear the expected pickup or pickup pair for every switch position.
     </ProcStep>
 </Proc>
-

--- a/content/relay/wiring/index.mdx
+++ b/content/relay/wiring/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Wiring'
-description: 'Bench-side wiring references for each Relay voicing. Build and test the harness before it goes in the body.'
+description: 'Bench-side wiring references for each Relay voicing.'
 ---
 
-Pick the voicing you're building and you'll get its bench-side wiring reference — the selector map, connection points, and the published harness. Build and test the harness outside the body first; it's far easier to debug on the bench than in the cavity.
+Pick the voicing you're building and you'll get its bench-side wiring reference: the selector map, connection points, and the published harness.

--- a/content/relay/wiring/lipstick.mdx
+++ b/content/relay/wiring/lipstick.mdx
@@ -5,10 +5,6 @@ description: 'Bench-side wiring reference for the published Relay Lipstick harne
 
 This is the bench-side reference for the published Relay Lipstick harness. It documents the core selector, volume, tone, output, and ground path clearly. The lipstick blend and contour switching remain more specialized than the other Relay models, so this page treats the published harness as a reference build rather than a beginner-proof recipe.
 
-<DocAlert level="important" title="Build the core harness first">
-    On Lipstick, prove the humbucker selector path, the main volume/tone path, and the ground bus before you add the lipstick blend branch. Debugging everything at once is where this model gets frustrating.
-</DocAlert>
-
 ## Control Layout
 
 <ControlPositions switchLabel="3-Way Toggle">

--- a/content/relay/wiring/torch.mdx
+++ b/content/relay/wiring/torch.mdx
@@ -5,10 +5,6 @@ description: 'Bench-side wiring reference for the Relay Torch base harness.'
 
 This is the bench-side reference for the Relay Torch harness. It gives you the selector map, pickup roles, labeled connection points, and the published base wiring without trying to turn the page into a full soldering class.
 
-<DocAlert level="important" title="Build and prove the harness before installation">
-    Torch is easiest to debug while everything is loose on the bench. Wire the whole harness first, verify the selector map and output path, then mount it in the body.
-</DocAlert>
-
 ## Control Layout
 
 <ControlPositions switchLabel="5-Way Blade">

--- a/content/relay/wiring/velvet.mdx
+++ b/content/relay/wiring/velvet.mdx
@@ -5,10 +5,6 @@ description: 'Bench-side wiring reference for the Relay Velvet base harness.'
 
 This is the bench-side reference for the Relay Velvet harness. It gives you the selector map, pickup roles, labeled connection points, and the published base wiring without forcing a blow-by-blow soldering tutorial.
 
-<DocAlert level="important" title="Build and test the harness before installation">
-    Velvet rewards careful bench work. Wire the harness outside the body, verify the 5-way map and output path, then install it once the base circuit is quiet and correct.
-</DocAlert>
-
 ## Control Layout
 
 <ControlPositions switchLabel="5-Way Blade">


### PR DESCRIPTION
## Summary
- remove the page-top wiring admonition banners from Relay wiring pages and simplify related intro copy
- shorten Relay voice tab labels visually while preserving full accessible names
- give Relay voice tabs clearer bordered surfaces so options are distinguishable before hover

## Verification
- `npm run build` — 36 test files, 156 tests passed; Next.js production build and sitemap generation completed
- `git diff --check`
