### PR TITLE
Remove Relay preview banner

### DIFF
--- a/app/relay/layout.tsx
+++ b/app/relay/layout.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Info } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { PageNavigation } from '@/components/page-navigation';
 import { RelayLayoutSidebar } from '@/components/navigation/relay-sidebar';
@@ -7,14 +6,6 @@ import { RelayLayoutSidebar } from '@/components/navigation/relay-sidebar';
 export default function RelayLayout({ children }: { children: React.ReactNode }) {
     return (
         <>
-            <div className="border-b border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30">
-                <div className="container flex items-center gap-2 py-2.5 text-sm text-amber-800 dark:text-amber-300">
-                    <Info className="h-4 w-4 shrink-0" />
-                    <span>
-                        <strong>Preview</strong> — This is an early look at the Relay Guitar Platform. Content and specs may change before launch.
-                    </span>
-                </div>
-            </div>
             <div className="border-b">
                 <div className="container flex flex-col lg:flex-row lg:items-start">
                     <aside className="w-full lg:sticky lg:top-14 lg:-ml-2 lg:w-auto lg:min-w-[220px] lg:max-w-[280px]">


### PR DESCRIPTION
## Summary
- remove the Preview notice banner from the shared Relay layout
- drop the now-unused Info icon import

## Verification
- `npm run build` — 36 test files, 159 tests passed; Next.js production build and sitemap generation completed
- `npm run lint`
- `git diff --check`
