### PR TITLE
Update Relay voicing community CTAs with Discord forum threads

### DIFF
--- a/components/relay/relay-voicing-overview.test.tsx
+++ b/components/relay/relay-voicing-overview.test.tsx
@@ -1,20 +1,43 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { RelayVoicingOverview } from './relay-voicing-overview';
+import { RelayVoicingOverview, getRelayVoicingCommunityMessage } from './relay-voicing-overview';
+
+vi.mock('@/components/discord-community-callout', () => ({
+    DiscordCommunityCallout: ({ message, threadId }: { message?: string; threadId?: string }) => (
+        <div data-testid="discord-community-callout" data-thread-id={threadId}>
+            {message}
+        </div>
+    ),
+}));
+
+describe('getRelayVoicingCommunityMessage', () => {
+    it('prompts ready voicings about parts and wiring', () => {
+        expect(getRelayVoicingCommunityMessage({ name: 'Relay Lipstick', status: 'ready' } as never)).toMatch(/Building Lipstick\?/);
+        expect(getRelayVoicingCommunityMessage({ name: 'Relay Lipstick', status: 'ready' } as never)).toMatch(/parts choices/i);
+    });
+
+    it('prompts lab voicings to share early builds', () => {
+        expect(getRelayVoicingCommunityMessage({ name: 'Relay Reef', status: 'lab' } as never)).toMatch(/Following Reef\?/);
+    });
+
+    it('prompts concept voicings to follow development', () => {
+        expect(getRelayVoicingCommunityMessage({ name: 'Relay Hammer', status: 'concept' } as never)).toMatch(/Interested in Hammer\?/);
+    });
+});
 
 describe('RelayVoicingOverview', () => {
-    it('does not render a status badge or callout for ready voicings', () => {
-        render(<RelayVoicingOverview voicingSlug="velvet">Body copy</RelayVoicingOverview>);
+    it('does not render a status badge or callout for ready voicings', async () => {
+        render(await RelayVoicingOverview({ voicingSlug: 'velvet', children: 'Body copy' }));
 
         expect(screen.queryByText('Ready')).not.toBeInTheDocument();
         expect(screen.queryByText('Ready voicing')).not.toBeInTheDocument();
         expect(screen.getByText('Body copy')).toBeInTheDocument();
     });
 
-    it('renders a lab status callout before the overview text', () => {
-        const { container } = render(<RelayVoicingOverview voicingSlug="reef">Body copy</RelayVoicingOverview>);
+    it('renders a lab status callout before the overview text', async () => {
+        const { container } = render(await RelayVoicingOverview({ voicingSlug: 'reef', children: 'Body copy' }));
 
         expect(screen.getByText('Lab voicing')).toBeInTheDocument();
         const callout = container.querySelector('[data-relay-status-callout]');
@@ -22,9 +45,24 @@ describe('RelayVoicingOverview', () => {
         expect(callout && overview ? callout.compareDocumentPosition(overview) & Node.DOCUMENT_POSITION_FOLLOWING : 0).toBeTruthy();
     });
 
-    it('offers both Parts and Wiring as next-step links', () => {
-        render(<RelayVoicingOverview voicingSlug="lipstick">Body copy</RelayVoicingOverview>);
+    it('offers both Parts and Wiring as next-step links', async () => {
+        render(await RelayVoicingOverview({ voicingSlug: 'lipstick', children: 'Body copy' }));
         expect(screen.getByRole('link', { name: /parts/i })).toHaveAttribute('href', '/relay/parts?voicing=lipstick#electronics');
         expect(screen.getByRole('link', { name: /wiring/i })).toHaveAttribute('href', '/relay/wiring?voicing=lipstick');
+    });
+
+    it('renders the community callout after next build steps', async () => {
+        const { container } = render(await RelayVoicingOverview({ voicingSlug: 'lipstick', children: 'Body copy' }));
+
+        const nextSteps = container.querySelector('[data-relay-next-steps]');
+        const community = container.querySelector('[data-relay-community-callout]');
+        expect(nextSteps && community ? nextSteps.compareDocumentPosition(community) & Node.DOCUMENT_POSITION_FOLLOWING : 0).toBeTruthy();
+        expect(screen.getByTestId('discord-community-callout')).toHaveTextContent(/Building Lipstick\?/);
+        expect(screen.getByTestId('discord-community-callout')).toHaveAttribute('data-thread-id', '1523931871531110440');
+    });
+
+    it('uses the voicing forum channel for voicings without a dedicated thread', async () => {
+        render(await RelayVoicingOverview({ voicingSlug: 'reef', children: 'Body copy' }));
+        expect(screen.getByTestId('discord-community-callout')).toHaveAttribute('data-thread-id', '1523931332428828723');
     });
 });

--- a/components/relay/relay-voicing-overview.tsx
+++ b/components/relay/relay-voicing-overview.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils';
 import { relayVoicings } from '@/config/relay-voicings';
 import type { RelayVoicing, RelayVoicingStatus } from '@/types/relay-voicing';
 import { RelayPickupMap } from '@/components/relay/relay-pickup-map';
+import { DiscordCommunityCallout } from '@/components/discord-community-callout';
+import { getRelayVoicingDiscordTarget } from '@/config/relay-discord';
 
 const statusCopy: Partial<Record<RelayVoicingStatus, { title: string; body: string; className: string }>> = {
     lab: {
@@ -23,7 +25,20 @@ function getRelayVoicing(slug: string): RelayVoicing | undefined {
     return relayVoicings.find((voicing) => voicing.slug === slug);
 }
 
-export function RelayVoicingOverview({ voicingSlug, children }: { voicingSlug: string; children: React.ReactNode }) {
+export function getRelayVoicingCommunityMessage(voicing: RelayVoicing): string {
+    const shortName = voicing.name.replace(/^Relay /, '');
+
+    switch (voicing.status) {
+        case 'ready':
+            return `Building ${shortName}? Ask about parts choices, wiring quirks, and substitutions before you order.`;
+        case 'lab':
+            return `Following ${shortName}? Share early builds and help validate the design as documentation catches up.`;
+        case 'concept':
+            return `Interested in ${shortName}? Follow development and share what draws you to this voice.`;
+    }
+}
+
+export async function RelayVoicingOverview({ voicingSlug, children }: { voicingSlug: string; children: React.ReactNode }) {
     const voicing = getRelayVoicing(voicingSlug);
 
     if (!voicing) {
@@ -31,6 +46,7 @@ export function RelayVoicingOverview({ voicingSlug, children }: { voicingSlug: s
     }
 
     const status = statusCopy[voicing.status];
+    const discord = getRelayVoicingDiscordTarget(voicingSlug);
 
     return (
         <>
@@ -59,7 +75,7 @@ export function RelayVoicingOverview({ voicingSlug, children }: { voicingSlug: s
 
             {children}
 
-            <div className="mt-8 rounded-lg border p-4">
+            <div data-relay-next-steps className="mt-8 rounded-lg border p-4">
                 <h2 className="text-base font-semibold">Next in your build</h2>
                 <p className="mt-1 text-sm text-muted-foreground">This voicing shares the Relay body and hardware; its electronics and wiring are specific to the sound you just picked.</p>
                 <div className="mt-3 flex flex-col gap-2 sm:flex-row">
@@ -72,6 +88,10 @@ export function RelayVoicingOverview({ voicingSlug, children }: { voicingSlug: s
                         Wiring guide
                     </Link>
                 </div>
+            </div>
+
+            <div data-relay-community-callout>
+                <DiscordCommunityCallout threadId={discord.threadId} channelHref={discord.channelHref} message={getRelayVoicingCommunityMessage(voicing)} />
             </div>
         </>
     );

--- a/config/relay-discord.test.ts
+++ b/config/relay-discord.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getRelayVoicingDiscordTarget, relayDiscordChannelHref, relayDiscordVoicingChannelHref, relayDiscordVoicingChannelId } from '@/config/relay-discord';
+
+describe('getRelayVoicingDiscordTarget', () => {
+    it('maps ready voicings with threads to their forum thread', () => {
+        expect(getRelayVoicingDiscordTarget('lipstick')).toEqual({
+            threadId: '1523931871531110440',
+            channelHref: 'https://discord.com/channels/1432214244459417693/1523931871531110440',
+        });
+        expect(getRelayVoicingDiscordTarget('velvet').threadId).toBe('1523932118407843971');
+        expect(getRelayVoicingDiscordTarget('arc').threadId).toBe('1523931607126376570');
+        expect(getRelayVoicingDiscordTarget('torch').threadId).toBe('1523931995607007273');
+    });
+
+    it('falls back to the voicing forum channel for voicings without a thread', () => {
+        for (const slug of ['reef', 'current', 'hammer']) {
+            expect(getRelayVoicingDiscordTarget(slug)).toEqual({
+                threadId: relayDiscordVoicingChannelId,
+                channelHref: relayDiscordVoicingChannelHref,
+            });
+        }
+    });
+});
+
+describe('relayDiscordChannelHref', () => {
+    it('builds a Discord channel URL from the Relay server id', () => {
+        expect(relayDiscordChannelHref('123')).toBe('https://discord.com/channels/1432214244459417693/123');
+    });
+});

--- a/config/relay-discord.ts
+++ b/config/relay-discord.ts
@@ -1,0 +1,28 @@
+export const RELAY_DISCORD_SERVER_ID = '1432214244459417693';
+
+export const relayDiscordVoicingChannelId = '1523931332428828723';
+
+export const relayDiscordVoicingThreads = {
+    lipstick: '1523931871531110440',
+    arc: '1523931607126376570',
+    torch: '1523931995607007273',
+    velvet: '1523932118407843971',
+} as const;
+
+export type RelayDiscordVoicingThreadSlug = keyof typeof relayDiscordVoicingThreads;
+
+export function relayDiscordChannelHref(channelOrThreadId: string): string {
+    return `https://discord.com/channels/${RELAY_DISCORD_SERVER_ID}/${channelOrThreadId}`;
+}
+
+export const relayDiscordVoicingChannelHref = relayDiscordChannelHref(relayDiscordVoicingChannelId);
+
+/** Resolves the voicing forum thread for a slug, or the parent channel when no thread exists yet. */
+export function getRelayVoicingDiscordTarget(slug: string): { threadId: string; channelHref: string } {
+    const threadId = slug in relayDiscordVoicingThreads ? relayDiscordVoicingThreads[slug as RelayDiscordVoicingThreadSlug] : relayDiscordVoicingChannelId;
+
+    return {
+        threadId,
+        channelHref: relayDiscordChannelHref(threadId),
+    };
+}

--- a/content/relay/voicings/arc/index.mdx
+++ b/content/relay/voicings/arc/index.mdx
@@ -55,5 +55,3 @@ Indie, ambient, clean pop, country, and effects-heavy players. Arc is especially
 If you substitute parts, the middle pickup must be articulate and open, not mid-heavy. The bridge should prioritize clarity over compression. Avoid dark, overly hot, or soft pickups because they reduce the separation that makes Arc work.
 
 </RelayVoicingPickupChoices>
-
-<RelayDiscordCta message="Interested in Arc? Join the Discord to follow development and share what draws you to this voice." />

--- a/content/relay/voicings/current/index.mdx
+++ b/content/relay/voicings/current/index.mdx
@@ -55,5 +55,3 @@ Funk, pop, and tight rhythm players. Current is for parts where timing, attack, 
 If you substitute parts, use a medium-output Alnico V bridge pickup around 9-11K and a clear, slightly lower-output neck. The middle pickup is critical: it should be focused, mid-forward, and fast. Avoid warm, scooped, or soft-attack middle pickups because they work against the model.
 
 </RelayVoicingPickupChoices>
-
-<RelayDiscordCta message="Interested in Current? Join the Discord to follow development and share what draws you to this voice." />

--- a/content/relay/voicings/hammer/index.mdx
+++ b/content/relay/voicings/hammer/index.mdx
@@ -51,5 +51,3 @@ Metal and hard rock players who want the Relay body and platform, but do not nee
 These are concept-stage targets. If you substitute parts before the model is finalized, prioritize tight low end, controlled high output, and clear attack. Avoid pickups that get loose in the bass or smear under saturation.
 
 </RelayVoicingPickupChoices>
-
-<RelayDiscordCta message="Interested in Hammer? Join the Discord to follow development and share what draws you to this voice." />

--- a/content/relay/voicings/index.mdx
+++ b/content/relay/voicings/index.mdx
@@ -11,4 +11,4 @@ A **Ready** badge means I've built and validated that voicing and its documentat
 
 ## Community
 
-<RelayDiscordCta message="Ask questions, share builds, and follow development as the voicings evolve." />
+<DiscordCommunityCallout threadId="1523931332428828723" channelHref="https://discord.com/channels/1432214244459417693/1523931332428828723" message="Choosing a voicing? Compare notes with other builders — ask about tone goals, tradeoffs between models, and what fits your style." />

--- a/content/relay/voicings/lipstick/index.mdx
+++ b/content/relay/voicings/lipstick/index.mdx
@@ -61,5 +61,3 @@ Blues, rock, alternative, and indie players who want a guitar that responds to t
 If you substitute parts, keep the humbuckers clear enough that the lipstick has something useful to shape. Avoid a middle pickup that is hot, dark, or louder than the humbuckers. The lipstick should add contour and air, not become the main voice.
 
 </RelayVoicingPickupChoices>
-
-<RelayDiscordCta message="Building a Lipstick? Share your progress and ask questions in the Discord." />

--- a/content/relay/voicings/reef/index.mdx
+++ b/content/relay/voicings/reef/index.mdx
@@ -57,5 +57,3 @@ Indie, surf, alt-country, shoegaze, and studio players who want radically differ
 If you substitute parts, keep the lipsticks low output with a wide frequency response. Avoid hot single coils or anything mid-heavy enough to collapse the lipstick subsystem into a generic Strat-style sound. The bridge pickup should contrast clearly with the lipsticks instead of trying to match them.
 
 </RelayVoicingPickupChoices>
-
-<RelayDiscordCta message="Following the Reef build? Join the Discord to ask questions, share early builds, and help shape the design." />

--- a/content/relay/voicings/torch/index.mdx
+++ b/content/relay/voicings/torch/index.mdx
@@ -65,5 +65,3 @@ Rock, pop, alternative, and modern country players. Torch fits players who want 
 If you substitute parts, the middle pickup must have strong midrange character. The bridge should be hot but not muddy. Avoid scooped pickups because they pull Torch away from the vocal, forward behavior that defines it.
 
 </RelayVoicingPickupChoices>
-
-<RelayDiscordCta message="Interested in Torch? Join the Discord to follow development and share what draws you to this voice." />

--- a/content/relay/voicings/velvet/index.mdx
+++ b/content/relay/voicings/velvet/index.mdx
@@ -67,5 +67,3 @@ Jazz-club performers, blues and soul players, chord-melody players, and anyone w
 If you substitute parts, use moderate-output Alnico II humbuckers with a soft attack. The middle pickup must be clear but not aggressive. Avoid high-output or ceramic humbuckers because they can make Velvet too stiff and bright for the role.
 
 </RelayVoicingPickupChoices>
-
-<RelayDiscordCta message="Interested in Velvet? Join the Discord to follow development and share what draws you to this voice." />

--- a/templates/relay/relay-voice.mdx
+++ b/templates/relay/relay-voice.mdx
@@ -57,5 +57,3 @@ voicing: '[model-slug]'
 [Substitution guidance. What should the builder keep in mind if swapping parts? Are there output level, impedance, or voicing constraints that matter for this design? If substitutions are not recommended for a specific pickup, say why clearly.]
 
 </RelayVoicingPickupChoices>
-
-<RelayDiscordCta message="Building a [Model Name]? Share your progress and ask questions in the Discord." />


### PR DESCRIPTION
## Summary
- Replace per-page `RelayDiscordCta` on voicing detail pages with `DiscordCommunityCallout`, rendered after the "Next in your build" section in `RelayVoicingOverview`
- Add status-aware community copy (ready vs lab vs concept) and centralize Discord forum channel/thread IDs in `config/relay-discord.ts`
- Link Lipstick, Velvet, Arc, and Torch to their dedicated forum threads; lab and concept voicings fall back to the voicing forum channel
- Update the `/relay/voicings` gallery page to use the same `DiscordCommunityCallout` pattern

## Test plan
- [ ] Visit `/relay/voicings/lipstick` — community CTA appears below "Next in your build" with Lipstick-specific copy
- [ ] Confirm Lipstick CTA links to the Lipstick forum thread (`1523931871531110440`)
- [ ] Visit `/relay/voicings/reef` — CTA links to the voicing forum channel (no dedicated thread yet)
- [ ] Visit `/relay/voicings` — gallery community CTA links to the voicing forum channel
- [ ] `npx vitest run config/relay-discord.test.ts components/relay/relay-voicing-overview.test.tsx`


Made with [Cursor](https://cursor.com)