### PR TITLE
Add genre to CPC26001 summary, release Relay Current

### DIFF
--- a/__tests__/config/relay-voicings.test.ts
+++ b/__tests__/config/relay-voicings.test.ts
@@ -43,7 +43,7 @@ describe('relayVoicings config', () => {
             velvet: 'ready',
             arc: 'ready',
             torch: 'ready',
-            current: 'lab',
+            current: 'ready',
             hammer: 'concept',
         });
     });

--- a/components/doc/relay-voicing-grid.test.tsx
+++ b/components/doc/relay-voicing-grid.test.tsx
@@ -28,7 +28,7 @@ describe('RelayVoicingGrid (config-driven)', () => {
         render(<RelayVoicingGrid />);
 
         const names = screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent);
-        expect(names?.slice(0, 4).sort()).toEqual(['Relay Arc', 'Relay Lipstick', 'Relay Torch', 'Relay Velvet']);
+        expect(names?.slice(0, 5).sort()).toEqual(['Relay Arc', 'Relay Current', 'Relay Lipstick', 'Relay Torch', 'Relay Velvet']);
         expect(names?.[names.length - 1]).toBe('Relay Hammer');
     });
 

--- a/config/relay-discord.test.ts
+++ b/config/relay-discord.test.ts
@@ -10,10 +10,11 @@ describe('getRelayVoicingDiscordTarget', () => {
         expect(getRelayVoicingDiscordTarget('velvet').threadId).toBe('1523932118407843971');
         expect(getRelayVoicingDiscordTarget('arc').threadId).toBe('1523931607126376570');
         expect(getRelayVoicingDiscordTarget('torch').threadId).toBe('1523931995607007273');
+        expect(getRelayVoicingDiscordTarget('current').threadId).toBe('1530796354341834903');
     });
 
     it('falls back to the voicing forum channel for voicings without a thread', () => {
-        for (const slug of ['reef', 'current', 'hammer']) {
+        for (const slug of ['reef', 'hammer']) {
             expect(getRelayVoicingDiscordTarget(slug)).toEqual({
                 threadId: relayDiscordVoicingChannelId,
                 channelHref: relayDiscordVoicingChannelHref,

--- a/config/relay-discord.ts
+++ b/config/relay-discord.ts
@@ -7,6 +7,7 @@ export const relayDiscordVoicingThreads = {
     arc: '1523931607126376570',
     torch: '1523931995607007273',
     velvet: '1523932118407843971',
+    current: '1530796354341834903',
 } as const;
 
 export type RelayDiscordVoicingThreadSlug = keyof typeof relayDiscordVoicingThreads;

--- a/config/relay-voicings.ts
+++ b/config/relay-voicings.ts
@@ -127,7 +127,7 @@ export const relayVoicings: RelayVoicing[] = [
         tagline: 'Fast attack · Upper-mid focus',
         genres: 'Funk · Pop · Rock',
         description: 'A rhythm-first humbucker model with a middle augment layer that tightens lows, sharpens attack, and improves mix placement without acting like a boost.',
-        status: 'lab',
+        status: 'ready',
         interaction: {
             category: 'Augment layer',
             summary: 'The middle pickup is added after the humbucker selection to tighten lows and sharpen attack.',

--- a/content/instruments/CPC26001.mdx
+++ b/content/instruments/CPC26001.mdx
@@ -3,7 +3,7 @@ publish: true
 name: 'Coupeville Current'
 completed: '2026'
 origin: 'The first production Coupeville Current, personally crafted by Rhy Mednick in 2026.'
-theme: 'Familiar humbucker voices shaped through a middle Filtertron, with six engineered presets ranging from pronounced interaction to the direct voice of the selected pickups.'
+theme: 'Familiar humbucker voices shaped through a middle Filtertron, with six engineered presets ranging from pronounced interaction to the direct voice of the selected pickups—voiced for funk, pop, and rock.'
 images:
     - src: '/images/instruments/CPC26001/placeholder.svg'
       alt: 'Placeholder artwork for Coupeville Current CPC26001; exact instrument photography is pending'

--- a/docs/superpowers/specs/2026-07-25-cpc26001-genre-current-release-design.md
+++ b/docs/superpowers/specs/2026-07-25-cpc26001-genre-current-release-design.md
@@ -1,0 +1,58 @@
+# CPC26001 genre summary + Relay Current release — design
+
+**Date:** 2026-07-25
+
+## Problem
+
+Two related content gaps around the Current voicing:
+
+1. The Coupeville Current serial-number record (CPC26001) doesn't state what the model
+   is voiced to do musically. The Relay Current voicing page communicates its genre focus
+   (funk / pop / rock), but the CPC26001 hero summary does not.
+2. Relay Current is still marked as a `lab` voicing (design defined but not physically
+   built/validated). It has since been built and released, so it should read as an active,
+   released model — not a lab experiment.
+
+## Changes
+
+### 1. Genre in the Coupeville hero summary
+
+The CPC26001 hero summary renders from the `theme` frontmatter field
+(`components/instrument/instrument-record-page.tsx`). Genre is woven into that prose
+sentence — the record type has no structured `genres` field, and the summary is descriptive
+prose rather than the badge-style genre dots used in the Relay voicing grid.
+
+- **File:** `content/instruments/CPC26001.mdx`
+- Genre text matches the Relay Current voicing it evolves from: funk, pop, and rock.
+- Appended clause: `…—voiced for funk, pop, and rock.`
+
+### 2. Relay Current marked released
+
+Voicing status is single-sourced in `config/relay-voicings.ts`. Flipping `current` from
+`lab` to `ready` is a data-only change that automatically:
+
+- swaps the badge from "Lab" to "Ready" (`relay-voicing-status-badge.tsx`),
+- removes the amber "Lab voicing" caution callout (`relay-voicing-overview.tsx`),
+- reorders it ahead of `concept` voicings (`sortRelayVoicings`),
+- switches the Discord community CTA to the released-voicing message.
+
+No Current MDX or component edits are needed — all lab-experiment framing is status-driven.
+
+### 3. Current Discord thread
+
+Current now has a dedicated Discord forum thread (`1530796354341834903`), added to
+`relayDiscordVoicingThreads` in `config/relay-discord.ts` so the released voicing links to
+its own thread instead of the parent forum channel.
+
+## Tests updated
+
+- `__tests__/config/relay-voicings.test.ts` — expected `current` status `lab` → `ready`.
+- `components/doc/relay-voicing-grid.test.tsx` — ordering assertion now covers 5 ready
+  voicings (adds Relay Current).
+- `config/relay-discord.test.ts` — `current` moved from forum-channel fallback to a mapped
+  thread assertion.
+
+## Verification
+
+- `npx vitest run` — 182 tests pass.
+- `npm run build` — compiles and generates sitemap.


### PR DESCRIPTION
## Summary

Two content updates around the Current voicing:

- **Coupeville Current genre** — the CPC26001 serial record didn't say what the model is voiced to do musically. Added the funk/pop/rock genre focus to the hero summary (`theme` frontmatter), matching the [Relay Current voicing](/relay/voicings/current) it evolves from. Woven into the summary prose as requested.
- **Relay Current released** — flipped `current` from `lab` to `ready` in `config/relay-voicings.ts`. This single-source change swaps the badge to "Ready", removes the "Lab voicing" caution callout, reorders it ahead of concept voicings, and switches the Discord CTA to the released-voicing message. No lab-experiment wording lives in the Current MDX — it's all status-driven.
- **Discord thread** — wired Current to its new dedicated forum thread (`1530796354341834903`).

## Tests

- `__tests__/config/relay-voicings.test.ts` — expected `current` status updated.
- `components/doc/relay-voicing-grid.test.tsx` — ordering assertion now covers 5 ready voicings.
- `config/relay-discord.test.ts` — `current` moved to a mapped-thread assertion.

## Verification

- `npx vitest run` — 182 tests pass.
- `npm run build` — compiles + sitemap generation succeeds.

Spec: `docs/superpowers/specs/2026-07-25-cpc26001-genre-current-release-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)