### PR TITLE
Catalog guitar model and documentation decisions

### DIFF
--- a/docs/engineering/extraction/README.md
+++ b/docs/engineering/extraction/README.md
@@ -1,0 +1,52 @@
+# Engineering Knowledge Extraction
+
+This directory contains persistent intermediate artifacts harvested from source conversations. Its contents preserve candidate knowledge and provenance; they are not engineering policy.
+
+## Scope
+
+- `sources/` contains one inventory per reviewed source.
+- `decision-ledger.md` consolidates candidates across sources.
+- Canonical standards, reference designs, decision records, and product documentation live outside this directory after review and promotion.
+
+## Evidence labels
+
+- **Confirmed:** Explicitly accepted by the owner.
+- **Corrected:** An earlier proposal was superseded later in the source.
+- **Proposed:** Suggested but not explicitly accepted.
+- **Observed:** Factual or contextual material that is not itself a decision.
+- **Unresolved:** Requires owner review or supporting evidence.
+
+## Required source entry fields
+
+Every candidate decision records:
+
+- a stable source-local ID;
+- a concise statement;
+- its evidence label;
+- source evidence or conversational context;
+- a proposed classification;
+- conflicts, corrections, or dependencies when applicable.
+
+## Classification vocabulary
+
+- Project or governance principle
+- Engineering standard
+- Reference design
+- Design decision
+- Platform, model, or voicing documentation
+- Serialized-instrument documentation
+- Listening note
+- Unresolved question
+- Discussion only
+
+## Promotion rule
+
+Extraction is not adoption. A candidate becomes authoritative only through an explicitly reviewed change to its canonical destination. Promotion must preserve a link back to the source inventory.
+
+## Editing rules
+
+- Preserve the source's terminology during extraction.
+- Separate cross-product conventions from product-specific facts.
+- Record contradictions and corrections instead of silently choosing one.
+- Do not infer owner approval from an assistant's confidence.
+- Do not delete source inventories merely because their contents have been promoted.

--- a/docs/engineering/extraction/decision-ledger.md
+++ b/docs/engineering/extraction/decision-ledger.md
@@ -117,7 +117,7 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 | [CRL-017](sources/2026-07-30-coupeville-reef-layout.md#crl-017--tone-capacitor-is-22-nf-not-22-µf) | Correct the tone capacitor to 22 nF rather than 22 µF. | Corrected | Platform, model, or voicing documentation | Awaiting review | — |
 | [CRL-018](sources/2026-07-30-coupeville-reef-layout.md#crl-018--reverse-independent-volume-connection) | Use pickup-to-wiper reverse-independent branch volumes. | Confirmed | Reference design | Awaiting review | — |
 | [CRL-019](sources/2026-07-30-coupeville-reef-layout.md#crl-019--a1m-sweep-failure-is-an-observed-build-result) | Record the non-monotonic A1M blend sweep as an observed failure. | Observed | Platform, model, or voicing documentation | Awaiting review | — |
-| [CRL-020](sources/2026-07-30-coupeville-reef-layout.md#crl-020--production-volume-taper-remains-unresolved) | Test B1M and possibly C1M before selecting the production taper. | Unresolved | Unresolved question | Needs resolution | — |
+| [CRL-020](sources/2026-07-30-coupeville-reef-layout.md#crl-020--linear-pots-solve-the-bulk-of-the-blend-problem) | Use linear branch-volume pots; they solved the bulk of Reef's mixing problem. | Confirmed | Design decision | Awaiting review | — |
 | [CRL-021](sources/2026-07-30-coupeville-reef-layout.md#crl-021--match-both-volume-values-and-tapers) | Match both branch-volume resistance values and tapers. | Proposed | Reference design | Needs resolution | — |
 | [CRL-022](sources/2026-07-30-coupeville-reef-layout.md#crl-022--parallel-loading-informs-the-1-m-choice) | Account for the parallel load of both always-connected volume tracks. | Confirmed | Reference design | Awaiting review | — |
 | [CRL-023](sources/2026-07-30-coupeville-reef-layout.md#crl-023--preserve-1-m-unless-brightness-proves-excessive) | Retain 1 MΩ values unless the working guitar proves too bright. | Proposed | Design decision | Needs resolution | — |
@@ -141,7 +141,7 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 - RCCP-005 did not define a serial prefix. The later `CVL26001` record and canonical site-organization policy control; the `CPC26001` mention on the current model page is an implementation mismatch to review.
 - RCCP-012 records compact network values, but construction topology should come from a reviewed reference design or installed-instrument record rather than being inferred from the prose shorthand.
 - CRL-001 through CRL-014 capture the intended Coupeville Reef model identity and simple HLL implementation; predictions about completed tone remain separate from measured facts.
-- CRL-006, CRL-018, and CRL-022 describe one reusable two-branch passive architecture, while CRL-019 and CRL-020 show that its pot taper remains unresolved.
+- CRL-006, CRL-018, and CRL-022 describe one reusable two-branch passive architecture; CRL-019 records the failed A1M sweep, and CRL-020 confirms that linear pots solved the bulk of it.
 - CRL-011 supersedes the early six-way, series-lipstick, bass-contour, and phase proposals for the simple baseline model.
 - CRL-013 is measured source data; CRL-014 is an interpretation that requires listening confirmation.
 - CRL-015 may inform a future pickup-measurement standard but is not yet an approved cross-platform rule.
@@ -167,7 +167,7 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 17. How much of the Current instrument record's installed architecture belongs on the public model page versus a shared Harmonic Shaper reference?
 18. Which proposed post-build note fields belong in model documentation, serialized-instrument documentation, or a reusable listening-note template?
 19. Is “the lipsticks are the instrument; the humbucker is the alternate voice” the accepted canonical Coupeville Reef identity?
-20. What taper wins the Reef branch-volume experiment: B1M linear, C1M reverse-audio, or another measured option?
+20. What resistance value was installed in the successful Reef linear pots, and what residual blend behavior remains?
 21. Does either Reef volume branch receive a treble bleed after the taper problem is corrected?
 22. What is the exact model and magnet of the measured 7.6 kΩ GFS neck humbucker, and was it retained in the completed instrument?
 23. Should the two-branch reverse-independent volume architecture become a reference design before its taper and sweep are validated?

--- a/docs/engineering/extraction/decision-ledger.md
+++ b/docs/engineering/extraction/decision-ledger.md
@@ -12,6 +12,7 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 
 ## Sources
 
+- [CVPC — Coupeville Velvet Pickup Comparison](sources/2026-07-30-coupeville-velvet-pickup-comparison.md)
 - [ZGDC — Zebrawood Guitar Documentation Conversation](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md)
 
 ## Candidates
@@ -50,6 +51,27 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 | [ZGDC-030](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-030--small-reviewable-changes) | Use small, reviewable changes throughout migration. | Confirmed | Project or governance principle | Awaiting review | — |
 | [ZGDC-031](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-031--example-top-level-hierarchies) | Adopt the conversation's example top-level hierarchies. | Proposed | Unresolved question | Needs resolution | — |
 | [ZGDC-032](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-032--separate-universal-ai-contribution-file) | Add a separate universal AI contribution file. | Proposed | Unresolved question | Needs resolution | — |
+| [CVPC-001](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-001--velvet-and-current-differ-through-player-experience) | Distinguish Velvet and Current through player experience despite hardware overlap. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
+| [CVPC-002](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-002--pickup-set-for-this-coupeville-velvet) | Use the measured ’59/Retrotron/’59 pickup set for this Velvet. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CVPC-003](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-003--do-not-use-reverse-independent-volumes) | Use pickup selection and master controls instead of reverse-independent volumes. | Confirmed | Design decision | Awaiting review | — |
+| [CVPC-004](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-004--nashville-centered-five-way-selection) | Use a Nashville-centered bridge-to-neck five-way sequence. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CVPC-005](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-005--master-performance-controls) | Keep selector, master volume, master tone, and partial split in the main control area. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CVPC-006](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-006--global-partial-split-for-outer-humbuckers) | Globally partial-split the outer humbuckers while keeping Nashville full. | Confirmed | Design decision | Awaiting review | — |
+| [CVPC-007](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-007--initial-fixed-split-resistors) | Start both outer partial splits at 2.2 kΩ. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
+| [CVPC-008](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-008--physical-control-hierarchy) | Put the Harmonic Shaper on the horn as an instrument-level preset. | Confirmed | Design decision | Awaiting review | — |
+| [CVPC-009](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-009--conventional-instrument-first) | Make Coupeville work conventionally first and reward optional exploration. | Confirmed | Project or governance principle | Awaiting review | — |
+| [CVPC-010](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-010--numbered-presets-with-visible-bypass) | Use numbered presets and mark Position 6 as bypass. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
+| [CVPC-011](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-011--harmonic-shaper-purpose) | Treat the Harmonic Shaper as a repeatable pickup-load character preset. | Confirmed | Reference design | Awaiting review | — |
+| [CVPC-012](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-012--six-position-progression) | Progress from strongest shaping at 1 to bypass at 6. | Confirmed | Reference design | Awaiting review | — |
+| [CVPC-013](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-013--starting-harmonic-shaper-networks) | Start with five specified series RC networks and open bypass. | Confirmed | Reference design | Awaiting review | — |
+| [CVPC-014](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-014--actual-shared-node-behavior) | Recognize that a shunt on the shared volume-input node loads every active pickup. | Corrected | Design decision | Awaiting review | — |
+| [CVPC-015](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-015--buildable-passive-shaper-connection) | Shunt the master input and use the blade to disconnect Nashville-only. | Corrected | Reference design | Awaiting review | — |
+| [CVPC-016](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-016--honest-effect-matrix) | Document that blend positions shape the combined pickup voice. | Corrected | Platform, model, or voicing documentation | Awaiting review | — |
+| [CVPC-017](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-017--keep-split-wiring-local-and-fixed) | Keep fixed split networks local instead of routing series links to the horn. | Corrected | Design decision | Awaiting review | — |
+| [CVPC-018](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-018--reserve-unused-rotary-poles) | Leave unused rotary poles available for later local refinements. | Proposed | Design decision | Needs resolution | — |
+| [CVPC-019](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-019--preserve-orthogonal-control-roles) | Keep phase, series selection, and unrelated tricks out of the shaper. | Proposed | Design decision | Needs resolution | — |
+| [CVPC-020](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-020--available-part-substitutions) | Approximate nominal shaper networks from the available component set. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
+| [CVPC-021](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-021--reef-mixing-behavior-remains-an-observation) | Preserve Reef's volume anomaly as an observation pending measurement. | Observed | Platform, model, or voicing documentation | Needs resolution | — |
 
 ## Consolidation notes
 
@@ -58,6 +80,11 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 - ZGDC-021 and ZGDC-022 distinguish reusable design identity from a product's declaration of the revision it uses.
 - ZGDC-023 defines classification boundaries and should be reconciled with the repository's existing content terminology before promotion.
 - ZGDC-028 supersedes the earlier sequence that designed governance before harvesting conversations.
+- CVPC-002 through CVPC-008 define one planned Coupeville Velvet build and should not become cross-product requirements.
+- CVPC-011 through CVPC-013 preserve the saved Harmonic Shaper intent and starting values; CVPC-014 through CVPC-017 preserve the later electrical and physical corrections needed to build it honestly.
+- CVPC-014 and CVPC-016 supersede the earlier claim that a passive shunt could affect only the humbucker contribution after its output shares a node with the Nashville.
+- CVPC-017 supersedes the position-dependent split-resistor proposal; CVPC-018 preserves unused rotary poles as an unresolved future choice rather than a feature requirement.
+- CVPC-021 is not a validated diagnosis of Reef. It records a symptom and the measurement gap that remains.
 
 ## Open questions
 
@@ -67,6 +94,13 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 4. How should “model,” “voicing,” “platform,” “product,” and “serialized instrument” be defined without disrupting existing site terminology?
 5. Should the existing `AGENTS.md` and `CLAUDE.md` point to a shared engineering front door, avoiding a separate `AI_CONTRIBUTING.md`?
 6. Which zebrawood wiring decisions belong in a future product record, reference design, or serialized-instrument record?
+7. Does the combined Velvet/Current concept redefine either model, or is it only the configuration of one Coupeville instrument?
+8. Should the corrected shared-node behavior become the canonical Coupeville Velvet design even though the earlier humbucker-only behavior was explicitly saved as intent?
+9. Are 2.2 kΩ split resistors and the five nominal RC branches accepted prototype values, and where should post-build tuning results be recorded?
+10. Should the unused rotary poles remain inaccessible, terminate at labeled service points, or be reserved only conceptually?
+11. Are numbered shaper positions with a visibly marked Position 6 bypass part of the final player-facing design?
+12. Which actual components are available for this build, and have their markings and tolerances been checked independently of the source images?
+13. What measurements isolate the cause of Reef's near-full-volume level collapse?
 
 ## Promotion log
 

--- a/docs/engineering/extraction/decision-ledger.md
+++ b/docs/engineering/extraction/decision-ledger.md
@@ -13,6 +13,7 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 ## Sources
 
 - [CVPC — Coupeville Velvet Pickup Comparison](sources/2026-07-30-coupeville-velvet-pickup-comparison.md)
+- [CRL — Coupeville Reef Layout](sources/2026-07-30-coupeville-reef-layout.md)
 - [RCCP — Relay Current Coupeville Plan](sources/2026-07-30-relay-current-coupeville-plan.md)
 - [ZGDC — Zebrawood Guitar Documentation Conversation](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md)
 
@@ -97,6 +98,30 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 | [RCCP-022](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-022--owner-oriented-printable-case-card) | Make the case card a concise owner-oriented operating reference. | Confirmed | Serialized-instrument documentation | Awaiting review | — |
 | [RCCP-023](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-023--keep-platform-wording-separate-from-instrument-values) | Separate reusable shaper wording from instrument-specific values. | Confirmed | Engineering standard | Awaiting review | — |
 | [RCCP-024](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-024--preserve-space-for-post-build-learning) | Support amplifier, string, listening, and revision notes. | Proposed | Listening note | Needs resolution | — |
+| [CRL-001](sources/2026-07-30-coupeville-reef-layout.md#crl-001--lipsticks-define-reef) | Treat the lipstick subsystem as Reef's defining instrument voice. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
+| [CRL-002](sources/2026-07-30-coupeville-reef-layout.md#crl-002--coupeville-reef-uses-an-hll-layout) | Use neck humbucker, middle lipstick, and bridge lipstick placement. | Confirmed | Design decision | Awaiting review | — |
+| [CRL-003](sources/2026-07-30-coupeville-reef-layout.md#crl-003--voice-family-roles) | Describe the predicted musical role of each Reef pickup voice. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
+| [CRL-004](sources/2026-07-30-coupeville-reef-layout.md#crl-004--simple-lipstick-selector) | Select bridge lipstick, both parallel, or middle lipstick. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CRL-005](sources/2026-07-30-coupeville-reef-layout.md#crl-005--selector-orientation-follows-pickup-direction) | Orient the selector lever toward the emphasized lipstick. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
+| [CRL-006](sources/2026-07-30-coupeville-reef-layout.md#crl-006--separate-lipstick-and-humbucker-branches) | Feed one lipstick volume and one humbucker volume into a shared bus. | Confirmed | Reference design | Awaiting review | — |
+| [CRL-007](sources/2026-07-30-coupeville-reef-layout.md#crl-007--global-master-tone) | Place one master tone after the branch outputs join. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CRL-008](sources/2026-07-30-coupeville-reef-layout.md#crl-008--continuous-branch-interaction-is-the-custom-feature) | Make continuous branch interaction Reef's primary custom behavior. | Confirmed | Design decision | Awaiting review | — |
+| [CRL-009](sources/2026-07-30-coupeville-reef-layout.md#crl-009--initial-build-remains-simple) | Build the initial control system without extra push-pull functions. | Confirmed | Design decision | Awaiting review | — |
+| [CRL-010](sources/2026-07-30-coupeville-reef-layout.md#crl-010--partial-split-is-the-only-initial-expansion-candidate) | Consider only a validated partial split as the first expansion. | Proposed | Design decision | Needs resolution | — |
+| [CRL-011](sources/2026-07-30-coupeville-reef-layout.md#crl-011--superseded-complex-switch-proposals) | Exclude series, phase, bass-contour, and full-system switching from the baseline. | Corrected | Design decision | Awaiting review | — |
+| [CRL-012](sources/2026-07-30-coupeville-reef-layout.md#crl-012--selected-neck-humbucker-candidate) | Use the available 7.6 kΩ GFS neck humbucker initially. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CRL-013](sources/2026-07-30-coupeville-reef-layout.md#crl-013--recorded-neck-humbucker-measurements) | Preserve the measured neck-humbucker DCR, inductance, and Q. | Observed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CRL-014](sources/2026-07-30-coupeville-reef-layout.md#crl-014--neck-humbucker-role-after-measurement) | Treat the neck humbucker as a warm, sustaining counterweight. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
+| [CRL-015](sources/2026-07-30-coupeville-reef-layout.md#crl-015--pickup-measurement-practice) | Compare pickup DCR, inductance, and Q at 1 kHz and 100 Hz. | Proposed | Engineering standard | Needs resolution | — |
+| [CRL-016](sources/2026-07-30-coupeville-reef-layout.md#crl-016--initial-control-values) | Start with three 1 MΩ controls and a 22 nF tone capacitor. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CRL-017](sources/2026-07-30-coupeville-reef-layout.md#crl-017--tone-capacitor-is-22-nf-not-22-µf) | Correct the tone capacitor to 22 nF rather than 22 µF. | Corrected | Platform, model, or voicing documentation | Awaiting review | — |
+| [CRL-018](sources/2026-07-30-coupeville-reef-layout.md#crl-018--reverse-independent-volume-connection) | Use pickup-to-wiper reverse-independent branch volumes. | Confirmed | Reference design | Awaiting review | — |
+| [CRL-019](sources/2026-07-30-coupeville-reef-layout.md#crl-019--a1m-sweep-failure-is-an-observed-build-result) | Record the non-monotonic A1M blend sweep as an observed failure. | Observed | Platform, model, or voicing documentation | Awaiting review | — |
+| [CRL-020](sources/2026-07-30-coupeville-reef-layout.md#crl-020--production-volume-taper-remains-unresolved) | Test B1M and possibly C1M before selecting the production taper. | Unresolved | Unresolved question | Needs resolution | — |
+| [CRL-021](sources/2026-07-30-coupeville-reef-layout.md#crl-021--match-both-volume-values-and-tapers) | Match both branch-volume resistance values and tapers. | Proposed | Reference design | Needs resolution | — |
+| [CRL-022](sources/2026-07-30-coupeville-reef-layout.md#crl-022--parallel-loading-informs-the-1-m-choice) | Account for the parallel load of both always-connected volume tracks. | Confirmed | Reference design | Awaiting review | — |
+| [CRL-023](sources/2026-07-30-coupeville-reef-layout.md#crl-023--preserve-1-m-unless-brightness-proves-excessive) | Retain 1 MΩ values unless the working guitar proves too bright. | Proposed | Design decision | Needs resolution | — |
+| [CRL-024](sources/2026-07-30-coupeville-reef-layout.md#crl-024--treble-bleeds-remain-undecided) | Decide branch treble bleeds only after the blend controls work. | Proposed | Unresolved question | Needs resolution | — |
 
 ## Consolidation notes
 
@@ -115,6 +140,11 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 - RCCP-004 supersedes the prototype framing, and RCCP-001 supersedes the Relay Current and Coupeville Relay Current names for this instrument.
 - RCCP-005 did not define a serial prefix. The later `CVL26001` record and canonical site-organization policy control; the `CPC26001` mention on the current model page is an implementation mismatch to review.
 - RCCP-012 records compact network values, but construction topology should come from a reviewed reference design or installed-instrument record rather than being inferred from the prose shorthand.
+- CRL-001 through CRL-014 capture the intended Coupeville Reef model identity and simple HLL implementation; predictions about completed tone remain separate from measured facts.
+- CRL-006, CRL-018, and CRL-022 describe one reusable two-branch passive architecture, while CRL-019 and CRL-020 show that its pot taper remains unresolved.
+- CRL-011 supersedes the early six-way, series-lipstick, bass-contour, and phase proposals for the simple baseline model.
+- CRL-013 is measured source data; CRL-014 is an interpretation that requires listening confirmation.
+- CRL-015 may inform a future pickup-measurement standard but is not yet an approved cross-platform rule.
 
 ## Open questions
 
@@ -136,6 +166,12 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 16. Which document owns the exact Current Harmonic Shaper topology and revision after the compact source notation is promoted?
 17. How much of the Current instrument record's installed architecture belongs on the public model page versus a shared Harmonic Shaper reference?
 18. Which proposed post-build note fields belong in model documentation, serialized-instrument documentation, or a reusable listening-note template?
+19. Is “the lipsticks are the instrument; the humbucker is the alternate voice” the accepted canonical Coupeville Reef identity?
+20. What taper wins the Reef branch-volume experiment: B1M linear, C1M reverse-audio, or another measured option?
+21. Does either Reef volume branch receive a treble bleed after the taper problem is corrected?
+22. What is the exact model and magnet of the measured 7.6 kΩ GFS neck humbucker, and was it retained in the completed instrument?
+23. Should the two-branch reverse-independent volume architecture become a reference design before its taper and sweep are validated?
+24. Which predicted pickup-role descriptions have been confirmed by listening and are ready for the Coupeville Reef model page?
 
 ## Promotion log
 

--- a/docs/engineering/extraction/decision-ledger.md
+++ b/docs/engineering/extraction/decision-ledger.md
@@ -13,6 +13,7 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 ## Sources
 
 - [CVPC — Coupeville Velvet Pickup Comparison](sources/2026-07-30-coupeville-velvet-pickup-comparison.md)
+- [RCCP — Relay Current Coupeville Plan](sources/2026-07-30-relay-current-coupeville-plan.md)
 - [ZGDC — Zebrawood Guitar Documentation Conversation](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md)
 
 ## Candidates
@@ -72,6 +73,30 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 | [CVPC-019](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-019--preserve-orthogonal-control-roles) | Keep phase, series selection, and unrelated tricks out of the shaper. | Proposed | Design decision | Needs resolution | — |
 | [CVPC-020](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-020--available-part-substitutions) | Approximate nominal shaper networks from the available component set. | Proposed | Platform, model, or voicing documentation | Needs resolution | — |
 | [CVPC-021](sources/2026-07-30-coupeville-velvet-pickup-comparison.md#cvpc-021--reef-mixing-behavior-remains-an-observation) | Preserve Reef's volume anomaly as an observation pending measurement. | Observed | Platform, model, or voicing documentation | Needs resolution | — |
+| [RCCP-001](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-001--model-name-is-coupeville-current) | Name the model Coupeville Current. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [RCCP-002](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-002--relay-and-coupeville-names-have-different-roles) | Use Relay for the builder platform and Coupeville for crafted instruments. | Confirmed | Project or governance principle | Needs resolution | — |
+| [RCCP-003](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-003--current-lineage-crosses-platforms-without-coupling-implementations) | Share Current lineage while keeping platform implementations distinct. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [RCCP-004](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-004--first-production-instrument-not-prototype) | Treat the instrument as the first production Current, not a prototype. | Corrected | Serialized-instrument documentation | Awaiting review | — |
+| [RCCP-005](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-005--use-established-serial-number-rules) | Apply established production serial rules rather than inventing a prototype number. | Confirmed | Serialized-instrument documentation | Needs resolution | — |
+| [RCCP-006](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-006--preserve-the-established-current-pickup-set) | Preserve the established Relay Current pickup models. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [RCCP-007](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-007--humbuckers-remain-the-primary-selectable-voices) | Use neck, neck-plus-bridge, and bridge as the primary selectable voices. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [RCCP-008](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-008--hot-nashville-is-a-shaper-not-a-selector-voice) | Use the Hot Nashville only as a harmonic shaper. | Confirmed | Design decision | Awaiting review | — |
+| [RCCP-009](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-009--master-volume-and-tone-specification) | Use A500K master volume and tone with a 22 nF tone capacitor. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [RCCP-010](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-010--production-treble-bleed) | Use a parallel 680 pF and 150 kΩ treble bleed. | Confirmed | Platform, model, or voicing documentation | Awaiting review | — |
+| [RCCP-011](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-011--six-repeatable-presets-replace-continuous-blend) | Replace the continuous blend with six repeatable shaper presets. | Confirmed | Design decision | Awaiting review | — |
+| [RCCP-012](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-012--current-production-reference-network) | Use the six documented Current production-reference networks. | Confirmed | Reference design | Needs resolution | — |
+| [RCCP-013](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-013--reference-values-may-evolve-through-listening) | Revise future reference values through documented listening tests. | Confirmed | Reference design | Awaiting review | — |
+| [RCCP-014](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-014--platform-wide-documentation-philosophy) | Apply one shaper documentation philosophy across equipped models. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-015](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-015--number-positions-instead-of-naming-them) | Number Harmonic Shaper positions instead of naming them. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-016](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-016--write-from-the-players-perspective) | Write restrained player-facing descriptions instead of circuit or marketing labels. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-017](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-017--refer-to-the-selected-pickup-voice) | Refer to the selected pickup voice in shaper descriptions. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-018](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-018--canonical-harmonic-shaper-explanation) | Reuse the canonical explanation of what the Harmonic Shaper modifies. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-019](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-019--canonical-six-position-descriptions) | Reuse the six accepted player-facing position descriptions. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-020](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-020--player-language-precedes-technical-reference) | Present player language before secondary component details. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-021](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-021--instrument-record-tone-and-purpose) | Write instrument records as restrained boutique technical references. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-022](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-022--owner-oriented-printable-case-card) | Make the case card a concise owner-oriented operating reference. | Confirmed | Serialized-instrument documentation | Awaiting review | — |
+| [RCCP-023](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-023--keep-platform-wording-separate-from-instrument-values) | Separate reusable shaper wording from instrument-specific values. | Confirmed | Engineering standard | Awaiting review | — |
+| [RCCP-024](sources/2026-07-30-relay-current-coupeville-plan.md#rccp-024--preserve-space-for-post-build-learning) | Support amplifier, string, listening, and revision notes. | Proposed | Listening note | Needs resolution | — |
 
 ## Consolidation notes
 
@@ -85,6 +110,11 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 - CVPC-014 and CVPC-016 supersede the earlier claim that a passive shunt could affect only the humbucker contribution after its output shares a node with the Nashville.
 - CVPC-017 supersedes the position-dependent split-resistor proposal; CVPC-018 preserves unused rotary poles as an unresolved future choice rather than a feature requirement.
 - CVPC-021 is not a validated diagnosis of Reef. It records a symptom and the measurement gap that remains.
+- RCCP-001 through RCCP-013 provide the strongest model-level source set so far for expanding the Coupeville Current page.
+- RCCP-014 through RCCP-020 are platform-level presentation decisions for every model that uses a Harmonic Shaper; their wording is reusable while electrical networks remain model-specific.
+- RCCP-004 supersedes the prototype framing, and RCCP-001 supersedes the Relay Current and Coupeville Relay Current names for this instrument.
+- RCCP-005 did not define a serial prefix. The later `CVL26001` record and canonical site-organization policy control; the `CPC26001` mention on the current model page is an implementation mismatch to review.
+- RCCP-012 records compact network values, but construction topology should come from a reviewed reference design or installed-instrument record rather than being inferred from the prose shorthand.
 
 ## Open questions
 
@@ -101,6 +131,11 @@ This ledger consolidates candidate knowledge from reviewed sources. It is an ext
 11. Are numbered shaper positions with a visibly marked Position 6 bypass part of the final player-facing design?
 12. Which actual components are available for this build, and have their markings and tolerances been checked independently of the source images?
 13. What measurements isolate the cause of Reef's near-full-volume level collapse?
+14. Should the Coupeville Current model page replace its `CPC26001` reference with the canonical `CVL26001` serial?
+15. How should the Relay-builder-platform and Coupeville-crafted-line distinction be stated alongside `docs/architecture/site-organization.md`?
+16. Which document owns the exact Current Harmonic Shaper topology and revision after the compact source notation is promoted?
+17. How much of the Current instrument record's installed architecture belongs on the public model page versus a shared Harmonic Shaper reference?
+18. Which proposed post-build note fields belong in model documentation, serialized-instrument documentation, or a reusable listening-note template?
 
 ## Promotion log
 

--- a/docs/engineering/extraction/decision-ledger.md
+++ b/docs/engineering/extraction/decision-ledger.md
@@ -1,0 +1,73 @@
+# Engineering Decision Ledger
+
+This ledger consolidates candidate knowledge from reviewed sources. It is an extraction index, not an engineering standard. Canonical documents become authoritative only after explicit review and promotion.
+
+## Ledger status
+
+- **Awaiting review:** Extracted but not yet accepted for promotion.
+- **Needs resolution:** A correction, conflict, classification, or terminology question requires owner input.
+- **Ready to promote:** Reviewed and assigned to a canonical destination.
+- **Promoted:** Incorporated into a canonical artifact with a recorded destination.
+- **Not promoted:** Reviewed and intentionally retained only as source context.
+
+## Sources
+
+- [ZGDC — Zebrawood Guitar Documentation Conversation](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md)
+
+## Candidates
+
+| Candidate | Summary | Evidence | Proposed classification | Ledger status | Canonical destination |
+|---|---|---|---|---|---|
+| [ZGDC-001](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-001--repository-authority) | The repository is the authoritative shared knowledge source. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-002](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-002--decisions-become-artifacts) | Durable decisions become versioned artifacts rather than memories. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-003](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-003--preserve-engineering-intent) | Preserve engineering intent, not only implementation artifacts. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-004](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-004--start-from-established-practice) | Start from industry practice and justify deviations. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-005](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-005--preserve-musical-personality) | Preserve musical personality over theoretical optimization. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-006](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-006--player-intuitive-controls) | Favor controls that behave as players expect. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-007](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-007--measure-and-listen) | Validate through measurement and listening. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-008](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-008--classify-durable-discoveries) | Classify durable discoveries for appropriate artifacts. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-009](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-009--intent-before-implementation) | Begin wiring packages with design intent and musical goals. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-010](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-010--separate-specification-and-assembly) | Separate wiring specifications from assembly guides. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-011](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-011--schematic-purpose) | Use conventional schematics to explain circuit operation. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-012](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-012--harness-layout-perspective) | Show harness layouts from the cavity top view. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-013](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-013--canonical-pot-view) | Show pots from the bottom with solder lugs facing the reader. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-014](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-014--never-mirror-component-drawings) | Never mirror canonical component drawings for an installation. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-015](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-015--positional-pot-lug-language) | Prefer positional pot-lug language when numeric labels are ambiguous. | Confirmed | Engineering standard | Needs resolution | — |
+| [ZGDC-016](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-016--name-every-wire) | Name wires consistently for assembly and debugging. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-017](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-017--bench-page-presentation) | Use clear, printable, one-concept bench pages. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-018](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-018--wiring-package-contents) | Define a consistent content baseline for wiring packages. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-019](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-019--validation-and-failure-modes) | Include measured checks, behavior checks, and failure guidance. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-020](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-020--listening-notes) | Preserve structured post-build listening notes. | Confirmed | Listening note | Awaiting review | — |
+| [ZGDC-021](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-021--identify-and-revise-reusable-wiring-designs) | Give reusable wiring designs canonical identities and revisions. | Confirmed | Reference design | Awaiting review | — |
+| [ZGDC-022](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-022--declare-the-design-revision-used) | Products declare the exact reference-design revision used. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-023](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-023--separate-knowledge-classes) | Separate standards, reusable designs, rationale, and product discoveries. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-024](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-024--separate-rules-from-examples) | Distinguish requirements, recommendations, and examples. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-025](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-025--decision-record-contents) | Decision records preserve status, context, decision, consequences, and references. | Confirmed | Engineering standard | Awaiting review | — |
+| [ZGDC-026](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-026--knowledge-lifecycle-states) | Use review states for maturing candidate knowledge. | Confirmed | Unresolved question | Needs resolution | — |
+| [ZGDC-027](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-027--engineering-knowledge-cycle) | Follow an observe-to-teach engineering knowledge cycle. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-028](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-028--harvest-before-final-architecture) | Harvest persistent artifacts before finalizing the hierarchy. | Corrected | Project or governance principle | Awaiting review | — |
+| [ZGDC-029](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-029--source-inventories-and-consolidated-ledger) | Keep per-source inventories and a consolidated ledger. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-030](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-030--small-reviewable-changes) | Use small, reviewable changes throughout migration. | Confirmed | Project or governance principle | Awaiting review | — |
+| [ZGDC-031](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-031--example-top-level-hierarchies) | Adopt the conversation's example top-level hierarchies. | Proposed | Unresolved question | Needs resolution | — |
+| [ZGDC-032](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md#zgdc-032--separate-universal-ai-contribution-file) | Add a separate universal AI contribution file. | Proposed | Unresolved question | Needs resolution | — |
+
+## Consolidation notes
+
+- ZGDC-001, ZGDC-002, and ZGDC-003 overlap but are not duplicates: they separately establish authority, artifact persistence, and preservation of rationale.
+- ZGDC-009 through ZGDC-020 are likely to inform one guitar-documentation standard, but no standard exists yet.
+- ZGDC-021 and ZGDC-022 distinguish reusable design identity from a product's declaration of the revision it uses.
+- ZGDC-023 defines classification boundaries and should be reconciled with the repository's existing content terminology before promotion.
+- ZGDC-028 supersedes the earlier sequence that designed governance before harvesting conversations.
+
+## Open questions
+
+1. Should eventual documents use ES/RD/DD identifiers, descriptive filenames, or both?
+2. Should positional pot-lug names supplement or replace numeric lug identifiers?
+3. Which lifecycle states apply to standards, reference designs, decisions, and product documentation, and what transitions require owner approval?
+4. How should “model,” “voicing,” “platform,” “product,” and “serialized instrument” be defined without disrupting existing site terminology?
+5. Should the existing `AGENTS.md` and `CLAUDE.md` point to a shared engineering front door, avoiding a separate `AI_CONTRIBUTING.md`?
+6. Which zebrawood wiring decisions belong in a future product record, reference design, or serialized-instrument record?
+
+## Promotion log
+
+No candidates have been promoted.

--- a/docs/engineering/extraction/sources/2026-07-30-coupeville-reef-layout.md
+++ b/docs/engineering/extraction/sources/2026-07-30-coupeville-reef-layout.md
@@ -1,0 +1,287 @@
+# Coupeville Reef Layout — Decision Inventory
+
+## Source
+
+- **Title:** Coupeville Reef Layout
+- **Shared conversation:** <https://chatgpt.com/share/6a6c27ba-6a04-83e8-9579-03eda9cf88cb>
+- **Reviewed:** 2026-07-30
+- **Scope:** Coupeville Reef pickup placement, two-branch control architecture, pickup measurements, pot and tone values, simplicity decisions, and troubleshooting of reverse-wired independent volume controls.
+
+## Extraction notes
+
+- This inventory prioritizes decisions useful to future Coupeville Reef model-page documentation while also preserving reusable electrical observations.
+- The conversation begins with design exploration and continues into an assembled-guitar troubleshooting session. Proposed design intent, measured facts, and unverified diagnoses are kept distinct.
+- The final production pot taper is unresolved because the conversation ends before the proposed B1M, reversed A1M, or C1M experiments are reported.
+- The existing Coupeville Reef model page currently describes only the high-level contrast between voice families; most of the model architecture in this source is not yet represented there.
+
+## Coupeville Reef identity and layout
+
+### CRL-001 — Lipsticks define Reef
+
+**Statement:** In Reef, the two lipsticks form the defining instrument voice while the humbucker supplies an alternate, fuller workhorse voice.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** This distinguishes Reef from Relay Lipstick and from a conventional humbucker guitar with decorative alternate pickups. The owner continued the design on this premise but did not explicitly restate it as a final definition.
+
+### CRL-002 — Coupeville Reef uses an HLL layout
+
+**Statement:** Place a low-output humbucker at the neck, with lipstick pickups in the middle and bridge positions.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Design decision
+
+**Notes:** The owner proceeded by selecting and measuring a neck humbucker after discussing this layout. The neck humbucker provides body and sustain without displacing the lipsticks from Reef's bright, spatial identity.
+
+### CRL-003 — Voice-family roles
+
+**Statement:** The bridge lipstick is the sharpest and most percussive voice, the middle lipstick is fuller and less pointed, both lipsticks in parallel form the broad glassy voice, and the neck humbucker provides the thick, sustaining melodic counterweight.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** These descriptions are predictions based on placement and pickup type. They need post-build listening confirmation before becoming definitive model copy.
+
+### CRL-004 — Simple lipstick selector
+
+**Statement:** Use a three-way selector for bridge lipstick, both lipsticks in parallel, and middle lipstick.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The owner explicitly constrained the design to the available three-way switch. Lipstick series operation and full-system six-way routing were abandoned.
+
+### CRL-005 — Selector orientation follows pickup direction
+
+**Statement:** Orient the physical three-way lever so it points toward the emphasized lipstick pickup, without a clever reversal.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** This is an ergonomic recommendation rather than an explicitly accepted build decision.
+
+## Two-branch control architecture
+
+### CRL-006 — Separate lipstick and humbucker branches
+
+**Statement:** Route both lipsticks through the three-way selector into one shared lipstick volume; route the neck humbucker directly into its own volume; join the two volume outputs at the common output bus.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** The owner supplied this topology from prior successful experiments and constrained the design around it. The selector configures the lipstick subsystem before its shared volume.
+
+### CRL-007 — Global master tone
+
+**Statement:** Connect one master tone after the two volume branches join so it affects the complete output.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The tone circuit belongs on the common output rather than on either branch's wiper.
+
+### CRL-008 — Continuous branch interaction is the custom feature
+
+**Statement:** The two independent volume branches provide continuous interaction between the selected lipstick subsystem and the neck humbucker; that interaction is more central to Coupeville Reef than additional binary switching features.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Design decision
+
+**Notes:** The owner leaned toward simplicity, and the final simple recommendation retained the two volumes as the defining custom behavior.
+
+### CRL-009 — Initial build remains simple
+
+**Statement:** Build the three-way selector, lipstick volume, humbucker volume, and master tone without additional push-pull functions unless testing reveals a specific missing voice.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Design decision
+
+**Notes:** Bass contour and phase reversal were rejected as premature feature accumulation. Push-pull pots may be installed mechanically while leaving their switch sections unused.
+
+### CRL-010 — Partial split is the only initial expansion candidate
+
+**Statement:** If the neck humbucker proves to split well and a leaner humbucker branch is musically useful, a partial split is the only push-pull function with a strong initial case.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Design decision
+
+**Notes:** The later pickup measurements made the assistant less eager to split automatically. No split resistor or installed split was confirmed in this source.
+
+### CRL-011 — Superseded complex-switch proposals
+
+**Statement:** Do not make the initial Coupeville Reef depend on lipstick series wiring, a six-position full-system selector, lipstick bass contour, or variable out-of-phase blending.
+
+**Evidence:** Corrected
+
+**Proposed classification:** Design decision
+
+**Notes:** These ideas were explored and then superseded by the owner's preference for a simple, coherent instrument. They may remain experiments for another design but are not part of the selected Reef baseline.
+
+## Pickup selection and measurements
+
+### CRL-012 — Selected neck-humbucker candidate
+
+**Statement:** Use the available 7.6 kΩ GFS neck humbucker as the initial warm counterweight to the lipstick subsystem.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The exact GFS model and magnet were not identified in the conversation. The pickup was accepted for testing after measurement rather than from DCR alone.
+
+### CRL-013 — Recorded neck-humbucker measurements
+
+**Statement:** The candidate neck humbucker measures 4.29 H with Q 2.36 at 1 kHz and 4.62 H with Q 0.37 at 100 Hz, alongside approximately 7.6 kΩ DCR.
+
+**Evidence:** Observed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** These owner-supplied readings characterize a normal-to-warm PAF-like pickup with healthy 1 kHz Q. They belong in a builder or installed-instrument record if the pickup remains in the completed guitar.
+
+### CRL-014 — Neck-humbucker role after measurement
+
+**Statement:** Treat the measured neck humbucker as a full, mid-present, sustaining counterweight rather than an ultra-clear or airy humbucker.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** This is an engineering interpretation of the measurements and needs listening validation in the assembled instrument.
+
+### CRL-015 — Pickup measurement practice
+
+**Statement:** For pickup comparisons, record DCR, inductance, and Q at 1 kHz and 100 Hz; use the 1 kHz inductance as the primary comparison and compare the gap between pickup families rather than evaluating a pickup in isolation.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is a reusable measurement recommendation, not yet an approved project-wide measurement standard.
+
+## Pot, tone, and loading decisions
+
+### CRL-016 — Initial control values
+
+**Statement:** Start with two 1 MΩ volume controls, a 1 MΩ master tone, and a 22 nF tone capacitor to preserve lipstick chime while accommodating the neck humbucker.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The owner built or tested the guitar with 1 MΩ volume controls and explicitly confirmed the tone-cap discussion. The final production taper remains unresolved.
+
+### CRL-017 — Tone capacitor is 22 nF, not 22 µF
+
+**Statement:** The master tone capacitor is 22 nF, equivalently 0.022 µF or code `223`; 22 µF is not a passive guitar tone value for this design.
+
+**Evidence:** Corrected
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** This corrects a unit typo in the owner's question. A 47 nF starting value was rejected as likely to darken the neck humbucker too quickly.
+
+### CRL-018 — Reverse-independent volume connection
+
+**Statement:** For each branch, connect pickup or selector output to the pot wiper, one outer lug to the shared output bus, and the other outer lug to ground so turning one branch fully down does not directly ground the common output.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** The owner confirmed both pots were wired this way. This topology preserves independent endpoint behavior but does not remove passive loading or taper interaction.
+
+### CRL-019 — A1M sweep failure is an observed build result
+
+**Statement:** With A1M audio-taper pots in the reverse-independent topology, both controls exhibited an unusable non-monotonic sweep: full output at 10, collapse near 9, partial recovery around 8–7, and near silence through much of the remaining rotation.
+
+**Evidence:** Observed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** Because both pots behaved similarly, taper geometry is a strong hypothesis. The source does not contain the replacement-pot or reversed-lug result needed to close the diagnosis.
+
+### CRL-020 — Production volume taper remains unresolved
+
+**Statement:** Test matched B1M linear pots and, if reversing the A1M outer lugs produces a broad usable sweep in the opposite direction, consider matched C1M reverse-audio pots before choosing the production taper.
+
+**Evidence:** Unresolved
+
+**Proposed classification:** Unresolved question
+
+**Notes:** The assistant first recommended B1M, then refined that recommendation to include C1M after the owner proposed testing the other side of the logarithmic track. No test outcome is present.
+
+### CRL-021 — Match both volume values and tapers
+
+**Statement:** Use the same resistance value and taper for both branch volumes so their blend behavior remains as predictable and comparable as possible.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Reference design
+
+**Notes:** Mixed values do not load only their nominal pickup branch after the outputs join; the lower-value pot changes the common load seen by both pickup systems.
+
+### CRL-022 — Parallel loading informs the 1 MΩ choice
+
+**Statement:** Two equal always-connected volume-pot tracks act approximately as parallel loads at the shared output when full up, so two 1 MΩ controls present roughly 500 kΩ before additional tone and amplifier loading, while two 500 kΩ controls present roughly 250 kΩ.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** The owner explicitly checked this understanding. Once either wiper moves, the circuit is more complex than two fixed parallel resistors because pickup impedance and track division participate.
+
+### CRL-023 — Preserve 1 MΩ unless brightness proves excessive
+
+**Statement:** Resolve taper first while retaining 1 MΩ pot values; consider two 500 kΩ volumes only later as a deliberate global darkening change if the working blend remains too bright.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Design decision
+
+**Notes:** Two 500 kΩ branch volumes could remove the airy edge Reef is intended to preserve. The source contains no later listening result.
+
+### CRL-024 — Treble bleeds remain undecided
+
+**Statement:** Do not standardize a treble bleed on either Reef branch until the volume controls operate correctly and the assembled guitar reveals whether each branch benefits from preserved high-frequency response while being reduced.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Unresolved question
+
+**Notes:** The early discussion leaned toward a modest bleed on the lipstick branch and none on the neck humbucker, but the simple-build decision and later taper problem leave this unresolved.
+
+## Current repository reconciliation
+
+- `content/coupeville/models/reef.mdx` already captures the high-contrast two-voice-family identity but does not document the HLL placement, three-way lipstick subsystem, independent branch volumes, measured neck pickup, or unresolved volume-taper work.
+- `content/relay/voicings/reef/index.mdx` uses a bridge humbucker and a different Relay-specific control system. That is not automatically a conflict: CRL-002 is a Coupeville-specific implementation decision.
+- No permanent serialized-instrument record for this Coupeville Reef was found in the current repository. Exact installed parts and final taper should remain candidates until such a record exists.
+
+## Corrections and superseded proposals
+
+1. **Bridge humbucker default:** Superseded for this Coupeville layout by the neck-humbucker HLL arrangement.
+2. **Six-way full-system selector:** Superseded because the proposed truth table and shared lipstick volume required awkward full-system routing.
+3. **Four-way lipstick selector and series voice:** Superseded by the available three-way selector and parallel lipstick pair.
+4. **Bass contour and phase-reversal push-pulls:** Superseded by the simple initial build.
+5. **Automatic partial split:** Reduced to a future option only after the measured humbucker is heard in the completed instrument.
+6. **Incorrect normal-volume diagnosis:** Corrected when the owner confirmed pickup-to-wiper reverse-independent wiring.
+7. **Pot defect or phase as leading cause:** Deprioritized after both A1M controls showed the same repeatable sweep pattern.
+8. **B1M as the settled fix:** Reopened when the reversed-log-track experiment suggested C1M might provide more useful resolution.
+
+## Explicit exclusions
+
+- Image-search results and generated learning widgets embedded in the source.
+- Predictions about completed tones that have not been confirmed through listening.
+- A final production volume taper, because the relevant experiment is absent.
+- A partial-split resistor value, because no split was accepted for the initial build.

--- a/docs/engineering/extraction/sources/2026-07-30-coupeville-reef-layout.md
+++ b/docs/engineering/extraction/sources/2026-07-30-coupeville-reef-layout.md
@@ -11,7 +11,7 @@
 
 - This inventory prioritizes decisions useful to future Coupeville Reef model-page documentation while also preserving reusable electrical observations.
 - The conversation begins with design exploration and continues into an assembled-guitar troubleshooting session. Proposed design intent, measured facts, and unverified diagnoses are kept distinct.
-- The final production pot taper is unresolved because the conversation ends before the proposed B1M, reversed A1M, or C1M experiments are reported.
+- A later owner report confirms that replacing the audio-taper pots with linear pots solved the bulk of the Reef mixing problem. The exact installed resistance and any residual sweep behavior remain to be documented.
 - The existing Coupeville Reef model page currently describes only the high-level contrast between voice families; most of the model architecture in this source is not yet represented there.
 
 ## Coupeville Reef identity and layout
@@ -212,15 +212,15 @@
 
 **Notes:** Because both pots behaved similarly, taper geometry is a strong hypothesis. The source does not contain the replacement-pot or reversed-lug result needed to close the diagnosis.
 
-### CRL-020 — Production volume taper remains unresolved
+### CRL-020 — Linear pots solve the bulk of the blend problem
 
-**Statement:** Test matched B1M linear pots and, if reversing the A1M outer lugs produces a broad usable sweep in the opposite direction, consider matched C1M reverse-audio pots before choosing the production taper.
+**Statement:** Replacing the audio-taper branch-volume pots with linear pots solved the bulk of the Coupeville Reef mixing problem.
 
-**Evidence:** Unresolved
+**Evidence:** Confirmed
 
-**Proposed classification:** Unresolved question
+**Proposed classification:** Design decision
 
-**Notes:** The assistant first recommended B1M, then refined that recommendation to include C1M after the owner proposed testing the other side of the logarithmic track. No test outcome is present.
+**Notes:** The owner reported this result after the shared conversation was inventoried. It confirms taper geometry as the main cause and supersedes the proposed C1M experiment as the leading production direction. The update does not state the installed pot resistance, whether both pots have identical values, or what portion of the problem remains.
 
 ### CRL-021 — Match both volume values and tapers
 
@@ -277,11 +277,11 @@
 5. **Automatic partial split:** Reduced to a future option only after the measured humbucker is heard in the completed instrument.
 6. **Incorrect normal-volume diagnosis:** Corrected when the owner confirmed pickup-to-wiper reverse-independent wiring.
 7. **Pot defect or phase as leading cause:** Deprioritized after both A1M controls showed the same repeatable sweep pattern.
-8. **B1M as the settled fix:** Reopened when the reversed-log-track experiment suggested C1M might provide more useful resolution.
+8. **B1M versus C1M taper choice:** Resolved at the taper-family level by the owner's later report that linear pots solved the bulk of the problem; exact installed resistance and residual behavior remain undocumented.
 
 ## Explicit exclusions
 
 - Image-search results and generated learning widgets embedded in the source.
 - Predictions about completed tones that have not been confirmed through listening.
-- A final production volume taper, because the relevant experiment is absent.
+- The exact resistance value of the successful linear pots and any residual blend-sweep problem not described by the owner's later update.
 - A partial-split resistor value, because no split was accepted for the initial build.

--- a/docs/engineering/extraction/sources/2026-07-30-coupeville-velvet-pickup-comparison.md
+++ b/docs/engineering/extraction/sources/2026-07-30-coupeville-velvet-pickup-comparison.md
@@ -1,0 +1,248 @@
+# Coupeville Velvet Pickup Comparison — Decision Inventory
+
+## Source
+
+- **Title:** Pickup Comparison for Velvet
+- **Shared conversation:** <https://chatgpt.com/share/6a6c263d-0b70-83e8-8834-26667cd74dfd>
+- **Reviewed:** 2026-07-30
+- **Scope:** Coupeville Velvet pickup selection, control architecture, Harmonic Shaper behavior and implementation, partial splits, physical control hierarchy, and build-ready component values.
+
+## Extraction notes
+
+- This inventory records durable candidates; it does not make them policy.
+- The owner explicitly asked ChatGPT to save the selected Coupeville Velvet architecture and later the Harmonic Shaper specification. Those requests confirm the decisions as they stood at those points in the conversation.
+- Later bench-planning questions exposed electrical and physical problems in parts of the saved design. Corrected entries preserve both the intended behavior and the buildable passive behavior that replaced it.
+- Exact component values remain starting values until the completed instrument is measured and heard.
+
+## Model identity and control architecture
+
+### CVPC-001 — Velvet and Current differ through player experience
+
+**Statement:** Velvet and Current may use overlapping pickup hardware while remaining distinct through the control behavior and musical experience they encourage.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The conversation framed Velvet as preserving discrete Nashville-centered voices and Current as encouraging continuous humbucker shaping. The combined Coupeville design borrows from both, but the owner did not explicitly approve this wording as a formal model distinction.
+
+### CVPC-002 — Pickup set for this Coupeville Velvet
+
+**Statement:** The planned pickup set is a 7.23 kΩ Guitar Madness Alnico V ’59 neck humbucker, a 9.5 kΩ Nashville Vintage Retrotron center pickup, and an 8.45 kΩ Guitar Madness Alnico V ’59 bridge humbucker.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The owner supplied these measurements and asked to save the resulting Velvet reference design. The resistance readings identify the specific build candidates; they are not cross-product specifications.
+
+### CVPC-003 — Do not use reverse-independent volumes
+
+**Statement:** This Coupeville Velvet uses selection plus master controls rather than reverse-wired independent pickup volumes.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Design decision
+
+**Notes:** The architecture was selected to avoid the severe passive interaction observed on Reef and to keep each control's job understandable. This does not retroactively change Reef.
+
+### CVPC-004 — Nashville-centered five-way selection
+
+**Statement:** The five-way blade positions are bridge; bridge plus Nashville; Nashville; Nashville plus neck; neck.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The owner asked to save this architecture. The arrangement makes the Nashville the literal center and omits a neck-plus-bridge position.
+
+### CVPC-005 — Master performance controls
+
+**Statement:** The main control area contains the five-way pickup selector, master volume, master tone, and the global partial-split control.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** These are the familiar, performance-oriented controls. The partial split may share a pot through a push-pull or push-push mechanism.
+
+### CVPC-006 — Global partial split for outer humbuckers
+
+**Statement:** One global switch partially splits both outer PAF-style humbuckers when selected, while the Nashville remains a full humbucker in every position.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Design decision
+
+**Notes:** The owner asked to save this choice. Independent splits and a Nashville split were rejected to preserve a coherent interface and the Nashville's core Velvet identity.
+
+### CVPC-007 — Initial fixed split resistors
+
+**Statement:** The initial build uses a fixed 2.2 kΩ partial-split resistor for each outer humbucker, with a possible later bridge experiment at 3.3 kΩ if the bridge becomes too thin or loses too much output.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The final actionable recommendation returned to 2.2 kΩ on both pickups after abandoning position-dependent split resistors. The exact values were not followed by explicit owner approval and require listening validation.
+
+## Player experience and brand philosophy
+
+### CVPC-008 — Physical control hierarchy
+
+**Statement:** Place the six-way Harmonic Shaper on the upper horn, apart from the familiar controls in the lower control area, so its physical location communicates that it is an instrument-level preset rather than a control to ride continuously.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Design decision
+
+**Notes:** The owner proposed this layout and explicitly agreed with the resulting control-hierarchy rationale. Reach and clearance still require physical validation on the body.
+
+### CVPC-009 — Conventional instrument first
+
+**Statement:** Coupeville guitars should work beautifully as normal instruments first; unusual controls should reward curiosity rather than demand it.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** The owner described wanting a guitar that remains easy and good-sounding when the Harmonic Shaper is ignored, then explicitly endorsed the associated brand philosophy. The Harmonic Shaper's concise expression is “Set the character, then play the guitar normally.”
+
+### CVPC-010 — Numbered presets with visible bypass
+
+**Statement:** Label the Harmonic Shaper positions numerically, keep detailed voice descriptions in documentation, and identify Position 6 clearly as bypass.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** This supports the clean preset metaphor and avoids cluttering the instrument. The owner agreed with the broader control hierarchy but did not separately approve this labeling detail.
+
+## Harmonic Shaper intent and behavior
+
+### CVPC-011 — Harmonic Shaper purpose
+
+**Statement:** The Harmonic Shaper is a repeatable pickup-load preset that changes attack, resonant emphasis, breadth, and perceived character while retaining more clarity than a conventional tone roll-off.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** The owner explicitly asked to save this specification. It should feel like a character selector rather than a second tone control.
+
+### CVPC-012 — Six-position progression
+
+**Statement:** The six positions progress from strongest shaping at Position 1 through increasingly subtle shaping at Position 5, followed immediately by open-circuit bypass at Position 6.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** The saved specification established strongest shaping at 1 and bypass at 6. The final exchange clarified the intended monotonic order: roundest/softest, warm/composed, balanced warmth, open/softened edges, nearly direct, bypass.
+
+### CVPC-013 — Starting Harmonic Shaper networks
+
+**Statement:** Positions 1–5 use selectable series RC branches of 150 kΩ plus 1 nF; 220 kΩ plus 680 pF; 330 kΩ plus 470 pF; 470 kΩ plus 330 pF; and 680 kΩ plus 220 pF, with Position 6 open.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** The owner explicitly asked to save these as the starting specification. They are tuning values, not validated final values. Increasing resistance and decreasing capacitance make the effect progressively weaker.
+
+### CVPC-014 — Actual shared-node behavior
+
+**Statement:** When the humbucker and Nashville switch outputs join at the master-volume input, a passive shunt connected to that node loads every active pickup on that node; it cannot affect only the humbucker contribution in blade Positions 2 and 4.
+
+**Evidence:** Corrected
+
+**Proposed classification:** Design decision
+
+**Notes:** This corrects the earlier saved claim that the shaper could alter only the outer humbucker within a passive Nashville blend. Physical placement before the junction does not create electrical isolation once conductors share the same node.
+
+### CVPC-015 — Buildable passive shaper connection
+
+**Statement:** Connect the selected series RC branch as a shunt from the master-volume input node to ground, and route its ground return through a spare blade-switch pole that opens in Nashville-only Position 3.
+
+**Evidence:** Corrected
+
+**Proposed classification:** Reference design
+
+**Notes:** This is the final buildable passive recommendation. The blade enables the shunt in Positions 1, 2, 4, and 5 and disconnects it in Position 3; rotary Position 6 remains open in every blade position. The order of the resistor and capacitor in each series branch is electrically interchangeable.
+
+### CVPC-016 — Honest effect matrix
+
+**Statement:** The shaper affects bridge alone in Position 1, the combined bridge/Nashville voice in Position 2, nothing in Nashville-only Position 3, the combined Nashville/neck voice in Position 4, and neck alone in Position 5.
+
+**Evidence:** Corrected
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** This replaces the intended but unrealizable passive claim that the Nashville contribution remains entirely unshaped in blend positions. Isolating only the humbucker contribution would require buffering, mixing resistors, separate networks, or another architecture.
+
+### CVPC-017 — Keep split wiring local and fixed
+
+**Statement:** Keep each pickup series link and its fixed partial-split resistor local to the push-pull in the main control cavity rather than routing high-impedance series-link wiring to the horn rotary.
+
+**Evidence:** Corrected
+
+**Proposed classification:** Design decision
+
+**Notes:** This supersedes the proposed self-calibrating rotary scheme with position-dependent split resistors. The physical distance would add several feet of sensitive wiring and make the build harder to understand and service.
+
+### CVPC-018 — Reserve unused rotary poles
+
+**Statement:** Use only the rotary pole needed for the Harmonic Shaper in the initial build and leave the remaining poles unpopulated or accessible for later local refinements discovered through listening tests.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Design decision
+
+**Notes:** This reverses the assistant's earlier assertion that the four-pole switch was too valuable to leave unused. Any later use should manipulate signals already local to the shaper rather than add remote pickup connections merely to consume available poles.
+
+### CVPC-019 — Preserve orthogonal control roles
+
+**Statement:** Do not use the Harmonic Shaper rotary to add phase reversal, neck-plus-bridge series selection, or unrelated pickup-selection tricks; the blade chooses pickups and the rotary chooses character.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Design decision
+
+**Notes:** The conversation consistently favored refinement over feature count, but the owner did not explicitly save each rejected alternative as a final decision.
+
+## Build-specific component observations
+
+### CVPC-020 — Available-part substitutions
+
+**Statement:** The initial shaper may approximate its targets from available parts as 147 kΩ plus 1 nF; 220 kΩ plus 690 pF; 330 kΩ plus 470 pF; 470 kΩ plus 320 pF; and 690 kΩ plus 220 pF.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** These combinations were derived from components visible to ChatGPT in the source conversation. They should be checked against the actual parts before assembly. Small differences from the nominal targets were treated as acceptable relative to likely component tolerance.
+
+### CVPC-021 — Reef mixing behavior remains an observation
+
+**Statement:** Reef exhibited a severe level change near the top of reverse-wired independent linear volume controls, suggesting passive source interaction or end-of-track behavior that should be measured before generalizing a cause.
+
+**Evidence:** Observed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The assistant first blamed audio taper, then corrected that explanation when the owner clarified that the pots were linear. Pot resistance and isolated-path measurements were proposed but no results appear in this source, so the exact cause remains unvalidated.
+
+## Corrections and superseded proposals
+
+1. **Audio-taper explanation:** Superseded when the owner clarified that Reef uses linear pots.
+2. **Humbucker-only shaping in blends:** Superseded because the humbucker and Nashville outputs share one electrical node at the master-volume input.
+3. **Position-dependent split resistors on the horn rotary:** Superseded because the required long series-link wiring is physically undesirable.
+4. **Populate extra rotary poles because they are available:** Superseded by the simpler initial build with unused poles reserved.
+5. **Explore a different passive topology before producing an actionable plan:** Rejected for this build after the owner requested a circuit that could be wired immediately and once.
+
+## Explicit exclusions
+
+- The generated downloadable HTML file, which was a temporary sandbox artifact and is not available as a durable repository source.
+- Private ChatGPT memory operations, which do not make the saved decisions available to repository agents.
+- Predictions about tone or preferred positions that were not validated on the completed instrument.
+- The conversation's unseen component photographs as authoritative inventory evidence; actual component markings must be checked at the bench.

--- a/docs/engineering/extraction/sources/2026-07-30-relay-current-coupeville-plan.md
+++ b/docs/engineering/extraction/sources/2026-07-30-relay-current-coupeville-plan.md
@@ -1,0 +1,296 @@
+# Relay Current Coupeville Plan — Decision Inventory
+
+## Source
+
+- **Title:** Relay Current Coupeville Plan
+- **Shared conversation:** <https://chatgpt.com/share/6a6c26b2-b370-83e8-a534-008ee973e6b2>
+- **Reviewed:** 2026-07-30
+- **Scope:** Evolution of Relay Current into Coupeville Current, Current model identity and controls, Harmonic Shaper networks and player-facing language, platform naming, production status, serial-record requirements, and case-card content.
+
+## Extraction notes
+
+- This inventory prioritizes decisions useful to future Coupeville Current model-page documentation while also cataloging platform-level decisions.
+- The owner explicitly asked ChatGPT to remember the production design, position descriptions, platform-wide Harmonic Shaper philosophy, and final model name. Those requests are treated as confirmation at the point they occurred.
+- The conversation predates or accompanies the implemented `CVL26001` record. Current repository content is noted for reconciliation but does not retroactively alter the source evidence.
+- Network values are production-reference values in the source, with an explicit expectation of later listening-based revision.
+
+## Coupeville Current identity
+
+### RCCP-001 — Model name is Coupeville Current
+
+**Statement:** The instrument is named Coupeville Current, not Relay Current or Coupeville Relay Current.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The owner proposed the corrected name and ChatGPT recorded it as a saved decision. The name is implemented in `content/coupeville/models/current.mdx` and `content/instruments/CVL26001.mdx`.
+
+### RCCP-002 — Relay and Coupeville names have different roles
+
+**Statement:** Relay names the modular 3D-printed builder platform, while Coupeville names the personally crafted instrument line that may express related voicing ideas in a refined, complete form.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This platform distinction explains why a Current lineage can exist in both lines without naming the Coupeville instrument as a Relay derivative. It should be reconciled with the canonical site-organization policy before promotion.
+
+### RCCP-003 — Current lineage crosses platforms without coupling implementations
+
+**Statement:** Coupeville Current retains Relay Current's pickup voicing and tonal lineage while using a Coupeville-specific control architecture.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** This distinction is implemented in the current instrument record and reflected in the code comment that keeps Coupeville and Relay registries decoupled despite shared lineage.
+
+### RCCP-004 — First production instrument, not prototype
+
+**Statement:** The documented instrument is the first production Coupeville Current and must not be described as a prototype.
+
+**Evidence:** Corrected
+
+**Proposed classification:** Serialized-instrument documentation
+
+**Notes:** The source first proposed “Relay Current Prototype 001.” The owner explicitly rejected that status and directed that the instrument be treated as the first model off the production line. The implemented record describes `CVL26001` as the first production Coupeville Current.
+
+### RCCP-005 — Use established serial-number rules
+
+**Statement:** Generate the instrument serial from the repository's established production serial-number rules when the permanent record is created; do not improvise a prototype number.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Serialized-instrument documentation
+
+**Notes:** The conversation intentionally did not choose the serial itself. The later repository authority assigns `CVL26001`. The model page currently refers to `CPC26001`, which conflicts with the instrument record and canonical `CVL` namespace and should be reviewed during future model-page work.
+
+## Pickup and control architecture
+
+### RCCP-006 — Preserve the established Current pickup set
+
+**Statement:** Coupeville Current uses the exact pickup models already established for Relay Current: GFS Vintage 59 neck humbucker, GFS Retrotron Hot Nashville middle pickup, and GFS Professional Series Alnico V HOT bridge humbucker.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The owner corrected a handoff that treated the outer pickups as unspecified. The exact names are present in the Relay Current source and implemented `CVL26001` record.
+
+### RCCP-007 — Humbuckers remain the primary selectable voices
+
+**Statement:** A three-way selector chooses neck, neck plus bridge, or bridge; those humbucker selections remain the instrument's primary voices.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** This keeps the foundation familiar and prevents the center pickup from becoming another destination on the selector.
+
+### RCCP-008 — Hot Nashville is a shaper, not a selector voice
+
+**Statement:** The middle GFS Hot Nashville is used only as a passive harmonic-shaping element and is not presented as an independent pickup voice.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Design decision
+
+**Notes:** This is central to Current's identity. The source rejected turning the model into a conventional HSH guitar with more pickup combinations.
+
+### RCCP-009 — Master volume and tone specification
+
+**Statement:** Use an A500K master volume, an A500K master tone, and a 22 nF tone capacitor.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** These values were included in the saved architecture and final implementation handoff. They are implemented in `CVL26001`.
+
+### RCCP-010 — Production treble bleed
+
+**Statement:** Use a 680 pF capacitor and 150 kΩ resistor in parallel across the master-volume input and output.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Platform, model, or voicing documentation
+
+**Notes:** The owner explicitly asked ChatGPT to choose the bleed values, and the final handoff made them part of the production specification rather than a placeholder. The network is intended to preserve clarity without turning the rolled-down volume sound into an exaggerated EQ shift.
+
+### RCCP-011 — Six repeatable presets replace continuous blend
+
+**Statement:** Replace the continuously variable middle-pickup blend with a six-position Harmonic Shaper that selects repeatable passive voicing networks.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Design decision
+
+**Notes:** The owner explicitly preferred the voicing-network approach. Repeatability, documentation, comparison, and reuse were the main advantages.
+
+### RCCP-012 — Current production-reference network
+
+**Statement:** The six Harmonic Shaper positions use direct connection; 47 kΩ series resistance; 100 kΩ series resistance; 100 kΩ plus approximately 330 pF; 220 kΩ plus approximately 680 pF; and middle pickup disconnected.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** The owner asked to save these values, and the final handoff called them the current production reference implementation. The source does not fully specify the physical capacitor topology beyond the compact network notation; the implemented wiring documentation remains the stronger authority for construction detail.
+
+### RCCP-013 — Reference values may evolve through listening
+
+**Statement:** Preserve the six network values as a versioned reference implementation while allowing later revisions after listening tests.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** “Production reference” does not mean permanently immutable. A future change should be documented as a revision rather than silently overwriting the installed values of `CVL26001`.
+
+## Harmonic Shaper player documentation
+
+### RCCP-014 — Platform-wide documentation philosophy
+
+**Statement:** The Harmonic Shaper documentation philosophy applies to every Relay or Coupeville model that uses a shaper, even when model-specific component values differ.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** The owner explicitly broadened the philosophy from Current to all shaper-equipped submodels. Consistent language should help owners understand the control across instruments.
+
+### RCCP-015 — Number positions instead of naming them
+
+**Statement:** Harmonic Shaper positions are numbered rather than given evocative names.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** The owner preferred the nameless version. Numbering avoids telling players what they are supposed to hear and allows personal associations to develop through use.
+
+### RCCP-016 — Write from the player's perspective
+
+**Statement:** Describe what each position does for the selected pickup voice in restrained player-facing language, not through component values, circuit-designer terminology, or marketing adjectives.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** The owner accepted both the philosophy and revised wording. Technical values belong in the specification or builder record, not the primary explanation.
+
+### RCCP-017 — Refer to the selected pickup voice
+
+**Statement:** Use “selected pickup voice” in shaper descriptions so the language remains correct for neck, bridge, or both pickups without implying that a shaper position changes selector state.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This was an explicit owner edit to avoid descriptions that implied single- or dual-humbucker selection.
+
+### RCCP-018 — Canonical Harmonic Shaper explanation
+
+**Statement:** “The Harmonic Shaper modifies the character of the currently selected pickup voice. It does not select additional pickups or create separate voices. Instead, it offers six repeatable degrees of passive harmonic shaping, from maximum interaction to no interaction.”
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** The final handoff calls this wording canonical and reusable across future Relay and Coupeville models that use the feature.
+
+### RCCP-019 — Canonical six position descriptions
+
+**Statement:** Use the accepted numbered descriptions for maximum, strong, moderate, gentle, subtle, and bypassed harmonic shaping, all expressed relative to the selected pickup voice.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** The accepted wording is:
+
+1. Maximum harmonic shaping. The most pronounced interaction with the selected pickup voice.
+2. Strong harmonic shaping. Increases harmonic complexity while preserving the primary character.
+3. Moderate harmonic shaping. A balanced blend of clarity and interaction.
+4. Gentle harmonic shaping. Adds openness with a lighter touch.
+5. Subtle harmonic shaping. A slight enhancement to articulation and dimensionality.
+6. Harmonic shaper bypassed. The selected pickup voice passes unchanged.
+
+The descriptions are platform-level presentation language; the electrical implementation remains model-specific.
+
+### RCCP-020 — Player language precedes technical reference
+
+**Statement:** Present player-facing descriptions prominently and place resistor and capacitor values in a secondary technical specification or builder record.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This separation supports future owners without withholding the engineering record.
+
+## Model and instrument-page documentation
+
+### RCCP-021 — Instrument-record tone and purpose
+
+**Statement:** The permanent page should read as a boutique instrument specification and authoritative technical record for a future owner, emphasizing design intent, engineering choices, tonal philosophy, and repeatability without exaggerated marketing language.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** The final handoff repeatedly preserved this style. It aligns with the broader decision that documentation should explain why before implementation details.
+
+### RCCP-022 — Owner-oriented printable case card
+
+**Statement:** The printable case card should concisely identify the instrument, production serial, completion and builder information, pickups, controls, three-way selector behavior, canonical shaper explanation, and six numbered positions; component values are secondary if space permits.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Serialized-instrument documentation
+
+**Notes:** The card is for understanding and operating the instrument, not for replacing a wiring diagram or full builder record.
+
+### RCCP-023 — Keep platform wording separate from instrument values
+
+**Statement:** Implement reusable Harmonic Shaper wording separately from instrument-specific pickup, network, and installed-component values.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This supports consistent player language across models without coupling their electrical designs.
+
+### RCCP-024 — Preserve space for post-build learning
+
+**Statement:** The instrument documentation should support later listening notes, preferred amplifier and string pairings, and circuit revisions.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Listening note
+
+**Notes:** This appeared in both handoff drafts, but the owner did not separately approve the exact builder-notes fields. The broader listening-note practice is independently confirmed in ZGDC-020.
+
+## Current repository reconciliation
+
+- `content/instruments/CVL26001.mdx` implements the exact pickup set, controls, treble bleed, shaper networks, model identity, and first-production status recorded here.
+- `content/coupeville/models/current.mdx` describes the model's rhythm-first intent but does not yet explain the Harmonic Shaper or the Relay-to-Coupeville lineage in enough detail to stand alone as the model-level authority.
+- `content/coupeville/models/current.mdx` currently names the first instrument as `CPC26001`, while the canonical instrument record and site-organization policy use `CVL26001`. This is a candidate future model-page correction, not a decision supplied by the conversation.
+- `content/relay/voicings/current/index.mdx` preserves Relay Current's continuous or switched middle-layer implementation. That difference is compatible with shared lineage and distinct platform implementations.
+
+## Corrections and superseded proposals
+
+1. **Prototype identity:** Superseded by first-production Coupeville Current status.
+2. **Relay Current or Coupeville Relay Current name:** Superseded by Coupeville Current.
+3. **Continuous B500K/B1M middle blend:** Superseded for Coupeville Current by the six-position Harmonic Shaper.
+4. **Unspecified outer pickups in the first handoff:** Corrected to the established Relay Current pickup set.
+5. **Treble-bleed placeholder:** Corrected to the 680 pF and 150 kΩ parallel production network.
+6. **Named shaper positions:** Rejected in favor of numbered positions and restrained descriptions.
+7. **“Selected humbucker” wording:** Corrected to “selected pickup voice” so the descriptions also fit the both-humbuckers selector position.
+
+## Explicit exclusions
+
+- ChatGPT project-memory operations, which do not make decisions available to repository agents.
+- The suggestion that Codex could access ChatGPT's saved project memory; repository artifacts are the shared authority.
+- Any new serial prefix inferred from “Coupeville Current.” The later canonical repository policy defines `CVL` across Coupeville instruments.
+- Evocative position names such as Focus, Presence, Contour, Air, Bloom, Reference, Bold, Sweet, Pure, Dense, or Saturated.

--- a/docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md
+++ b/docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md
@@ -1,0 +1,354 @@
+# Zebrawood Guitar Documentation Conversation — Decision Inventory
+
+## Source
+
+- **Title:** Zebrawood Guitar Finish Tips
+- **Shared conversation:** <https://chatgpt.com/share/6a6c1c84-dd40-83e8-9c10-42f2d7d2ffe6>
+- **Reviewed:** 2026-07-30
+- **Scope:** Guitar wiring-documentation conventions, engineering-knowledge governance, reusable harness documentation, and transfer of durable decisions from AI conversations into the repository.
+
+## Extraction notes
+
+- This inventory records durable candidates; it does not make them policy.
+- Repeated owner replies of “Agreed” confirm the immediately preceding proposal unless a later correction supersedes it.
+- The conversation also contains product-specific zebrawood construction and wiring decisions. Those are excluded from cross-product candidates and summarized separately as product-specific observations.
+- ChatGPT first claimed that arbitrary agents could inherit saved memory, then corrected that claim. The corrected conclusion is that repository artifacts—not AI memory—must carry shared knowledge.
+
+## Project and governance candidates
+
+### ZGDC-001 — Repository authority
+
+**Statement:** The repository, rather than an AI's memory or conversation history, is the authoritative shared knowledge source.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This is a cross-product authority rule. It depends on future canonical documents being discoverable by both humans and agents.
+
+### ZGDC-002 — Decisions become artifacts
+
+**Statement:** Durable decisions should become versioned artifacts rather than memories.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This applies across the project. It establishes persistence but does not require every conversational remark to become an artifact.
+
+### ZGDC-003 — Preserve engineering intent
+
+**Statement:** The repository should preserve engineering intent—the reason behind a design—not only schematics, bills of materials, and procedures.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This is cross-product and depends on design-intent sections and decision records carrying rationale close to the relevant work.
+
+### ZGDC-004 — Start from established practice
+
+**Statement:** Begin with industry-standard practice and require a strong justification for deviations.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This is a cross-product decision heuristic, not a prohibition on experimentation.
+
+### ZGDC-005 — Preserve musical personality
+
+**Statement:** Preserve an instrument's musical personality over theoretical optimization.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This applies to guitar design generally and depends on each design documenting its intended musical identity.
+
+### ZGDC-006 — Player-intuitive controls
+
+**Statement:** Favor controls that behave intuitively and as a player expects.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This is cross-product. Product documentation should explain any intentional exception or unfamiliar interaction.
+
+### ZGDC-007 — Measure and listen
+
+**Statement:** Validate designs through both measurement and listening.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This applies across guitar engineering. It depends on validation records preserving objective checks and listening notes preserving subjective outcomes without conflating the two.
+
+### ZGDC-008 — Classify durable discoveries
+
+**Statement:** New durable knowledge should be classified and proposed for an appropriate repository artifact instead of remaining tribal knowledge.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This is cross-product. Classification is a review prompt, not a requirement to promote something from every conversation; discussion may remain discussion when it creates no durable knowledge.
+
+## Documentation and drawing candidates
+
+### ZGDC-009 — Intent before implementation
+
+**Statement:** Every wiring package begins with design intent and musical goals before implementation detail.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is a candidate cross-product documentation requirement. The source described the wiring as an implementation of the instrument's musical idea.
+
+### ZGDC-010 — Separate specification and assembly
+
+**Statement:** A wiring specification describes what the design is; a separate assembly guide describes how to build it.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is cross-product. The separation allows physical parts or procedures to change without silently changing the electrical design.
+
+### ZGDC-011 — Schematic purpose
+
+**Statement:** Electrical schematics use conventional notation and optimize for understanding circuit operation rather than physical assembly.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is a cross-product drawing convention and complements, rather than replaces, a physical harness layout.
+
+### ZGDC-012 — Harness-layout perspective
+
+**Statement:** Harness layouts use a top view of the control cavity and show physical component placement, routing, and wire identifiers.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is a cross-product drawing convention. Product-specific cavity geometry remains in the relevant assembly documentation.
+
+### ZGDC-013 — Canonical pot view
+
+**Statement:** Individual pot diagrams use the canonical bottom view, looking directly at the solder lugs with the lugs facing the reader.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** The first generated pot view was reversed from what the owner saw at the bench. The owner clarified that the view must be from the underside of the mounted pot “with the lugs facing you,” and explicitly accepted the corrected wording. This correction is essential context for any future drawing standard.
+
+### ZGDC-014 — Never mirror component drawings
+
+**Statement:** Component drawings are never mirrored to match a particular installation.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is cross-product. A physical component may be rotated in an installation, but its canonical detail drawing retains one learned orientation.
+
+### ZGDC-015 — Positional pot-lug language
+
+**Statement:** Prefer positional pot-lug language tied to the explicit viewing convention when numeric lug conventions could be ambiguous.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** The owner accepted the clarified viewing phrase, and the conversation proposed left, center, and right as less ambiguous identifiers. The exact balance between positional labels and conventional numeric identifiers remains subject to the eventual drawing standard.
+
+### ZGDC-016 — Name every wire
+
+**Statement:** Name wires consistently so assembly and debugging can trace each connection.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is cross-product. The source offered names such as `N_HOT` and `BUS_GND` as examples, not an approved universal naming schema.
+
+### ZGDC-017 — Bench-page presentation
+
+**Statement:** Use one concept per figure or page, minimize crossed wires, provide white space and large labels, and make bench documents printable on US Letter without scaling.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is a cross-product presentation convention intended to produce readable service-manual-style bench documents.
+
+### ZGDC-018 — Wiring-package contents
+
+**Statement:** Wiring packages include overview, schematic, harness layout, component details, grounding, assembly sequence, validation, revision history, and design intent.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is a cross-product content baseline. The eventual standard should reconcile ordering and determine which sections may be omitted when they are genuinely inapplicable.
+
+### ZGDC-019 — Validation and failure modes
+
+**Statement:** Validation includes output-jack resistance ranges, continuity checks, tap tests, expected control behavior, and useful failure-mode guidance.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is cross-product in principle. Exact measurements and troubleshooting steps remain specific to a reference design or product.
+
+### ZGDC-020 — Listening notes
+
+**Statement:** Post-build listening notes record surprises, possible changes, strengths, useful settings or playing contexts, and compatible future modifications.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Listening note
+
+**Notes:** This is a reusable product-documentation practice. Listening notes preserve subjective learning after construction and complement measured validation.
+
+## Reusable-design and lifecycle candidates
+
+### ZGDC-021 — Identify and revise reusable wiring designs
+
+**Statement:** Reusable wiring designs receive canonical identities and explicit revisions.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Reference design
+
+**Notes:** This is cross-product in intent. The conversation's example `RL-HAR-*` identifiers were illustrative and are not adopted as repository policy by this inventory.
+
+### ZGDC-022 — Declare the design revision used
+
+**Statement:** Product or instrument documentation identifies the exact reference-design revision used rather than duplicating the entire design.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is a cross-product anti-duplication rule. It depends on reference designs having stable identities, revisions, and accessible canonical records.
+
+### ZGDC-023 — Separate knowledge classes
+
+**Statement:** Standards contain stable cross-product rules; reusable solutions belong in reference designs; consequential rationale belongs in decision records; product discoveries belong in product documentation or listening notes.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This is cross-product. Its terms must be reconciled with the repository's existing Coupeville model, Relay voicing, wiring, and serialized-instrument structures before promotion.
+
+### ZGDC-024 — Separate rules from examples
+
+**Statement:** Standards distinguish requirements, recommendations, and examples so an example is not mistaken for a rule.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is cross-product and protects future contributors from promoting an illustrative value or layout into a mandatory convention.
+
+### ZGDC-025 — Decision-record contents
+
+**Statement:** Significant decisions record status, context, decision, consequences, and references.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Engineering standard
+
+**Notes:** This is a candidate cross-product requirement for consequential decision records. The exact metadata format remains a later design concern.
+
+### ZGDC-026 — Knowledge lifecycle states
+
+**Statement:** Candidate knowledge may move through Draft, Experimental, Validated, Approved, and Deprecated states.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Unresolved question
+
+**Notes:** The owner accepted the lifecycle concept, but the source did not resolve which artifact types use every state, who approves transitions, or whether a single linear sequence fits standards, reference designs, decisions, and product documentation equally well.
+
+### ZGDC-027 — Engineering knowledge cycle
+
+**Statement:** Engineering learning follows an observe, experiment, measure, listen, decide, document, reuse, and teach cycle.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This is a cross-product description of how knowledge matures. It is guidance rather than a required workflow for every small change.
+
+## Repository workflow and structure candidates
+
+### ZGDC-028 — Harvest before final architecture
+
+**Statement:** Harvest conversations into persistent intermediate artifacts before designing or populating the final knowledge hierarchy.
+
+**Evidence:** Corrected
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** The conversation first recommended building governance and directory structure before harvesting prior decisions. After the owner identified the risk of forcing unknown knowledge into premature categories—and then identified that an unwritten inventory would be lost—the recommendation was corrected to persistent source inventories plus a decision ledger before final architecture.
+
+### ZGDC-029 — Source inventories and consolidated ledger
+
+**Statement:** Preserve one source inventory per conversation and maintain a consolidated decision ledger.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This is a cross-product extraction practice. Individual inventories preserve provenance; the ledger supports deduplication, conflict detection, review, and promotion.
+
+### ZGDC-030 — Small reviewable changes
+
+**Statement:** Use small, reviewable changes for extraction, governance, standards, templates, and migration rather than one large refactor.
+
+**Evidence:** Confirmed
+
+**Proposed classification:** Project or governance principle
+
+**Notes:** This applies across the knowledge-system effort. The proposed example sequence was illustrative; actual boundaries should follow independently reviewable artifacts.
+
+### ZGDC-031 — Example top-level hierarchies
+
+**Statement:** Create separate top-level engineering and products hierarchies matching the examples in the conversation.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Unresolved question
+
+**Notes:** Literal adoption was never confirmed. This repository already uses `docs/`, `content/coupeville/models/`, `content/relay/voicings/`, `content/relay/wiring/`, and `content/instruments/`, governed in part by `docs/architecture/site-organization.md`. Any final structure must complement those authorities rather than create a competing public product hierarchy.
+
+### ZGDC-032 — Separate universal AI contribution file
+
+**Statement:** Add a separate root `AI_CONTRIBUTING.md` as the universal agent entry point.
+
+**Evidence:** Proposed
+
+**Proposed classification:** Unresolved question
+
+**Notes:** Literal adoption was never confirmed. The repository already has automatically discovered `AGENTS.md` and `CLAUDE.md`; a shared canonical engineering front door referenced by both may avoid a third duplicated instruction source.
+
+## Product-specific observations
+
+The source contains zebrawood-build facts and candidate wiring choices, including Mini ProBucker measurements, independent-volume behavior, treble-bleed values, partial-split proposals, finish advice, and weight decisions. These may be valuable to a future product record, reference design, or serialized-instrument record, but they are not extracted as cross-product standards in this phase.
+
+## Explicit exclusions
+
+- Generated images, diagrams, and sandbox download links that are not durable repository assets.
+- Assistant predictions about how the guitar will sound or which settings the owner will prefer.
+- Implementation examples not explicitly accepted as naming or directory policy.
+- Private ChatGPT memory operations that cannot provide repository-wide agent instructions.

--- a/docs/superpowers/plans/2026-07-30-guitar-engineering-knowledge-extraction.md
+++ b/docs/superpowers/plans/2026-07-30-guitar-engineering-knowledge-extraction.md
@@ -1,0 +1,487 @@
+# Guitar Engineering Knowledge Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve the durable guitar-documentation decisions from the reviewed ChatGPT conversation as traceable, reviewable extraction artifacts without promoting them into repository policy.
+
+**Architecture:** Add a deliberately limited staging area under `docs/engineering/extraction/`. One source inventory preserves provenance and records each candidate decision with an evidence label; one decision ledger provides the cross-source consolidation view; a short README defines how the staging area is used. No standards, reference designs, templates, published content, or agent instructions change in this phase.
+
+**Tech Stack:** Markdown, Git, ripgrep, repository documentation conventions
+
+## Global Constraints
+
+- The repository is the eventual source of truth, but extracted candidates are not policy until reviewed and promoted.
+- Create only `docs/engineering/extraction/README.md`, `docs/engineering/extraction/decision-ledger.md`, and `docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md`.
+- Do not create engineering standards, reference designs, decision records, templates, or other governance documents.
+- Do not modify `AGENTS.md`, `CLAUDE.md`, `docs/architecture/site-organization.md`, published `content/`, routes, navigation, or serialized-instrument behavior.
+- Preserve the existing distinctions among Coupeville models, Relay voicings, wiring documents, and serialized instruments; do not normalize those terms during extraction.
+- Use only these evidence labels: `Confirmed`, `Corrected`, `Proposed`, `Observed`, and `Unresolved`.
+- Every ledger entry must link to a source-inventory decision ID; every source-inventory decision must have a proposed classification or explicitly say `Discussion only`.
+- Product-specific component values and construction advice must not be represented as cross-product standards.
+- Leave genuinely ambiguous matters unresolved instead of inventing policy.
+- The source conversation is `https://chatgpt.com/share/6a6c1c84-dd40-83e8-9c10-42f2d7d2ffe6`, titled “Zebrawood Guitar Finish Tips,” reviewed on 2026-07-30.
+
+---
+
+## File Structure
+
+- `docs/engineering/extraction/README.md`: Defines the temporary extraction layer, evidence labels, entry requirements, promotion rule, and scope boundaries.
+- `docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md`: Preserves source metadata and the complete decision inventory for the reviewed conversation.
+- `docs/engineering/extraction/decision-ledger.md`: Provides a compact, cross-source list of candidate knowledge, classifications, statuses, conflicts, and open questions.
+
+### Task 1: Define the extraction staging area
+
+**Files:**
+- Create: `docs/engineering/extraction/README.md`
+
+**Interfaces:**
+- Consumes: The authority, extraction, and classification rules in `docs/superpowers/specs/2026-07-30-guitar-engineering-knowledge-design.md`.
+- Produces: The canonical format and evidence vocabulary used by the source inventory and decision ledger in Tasks 2 and 3.
+
+- [ ] **Step 1: Create the extraction README**
+
+Create `docs/engineering/extraction/README.md` with these exact sections and requirements:
+
+```markdown
+# Engineering Knowledge Extraction
+
+This directory contains persistent intermediate artifacts harvested from source conversations. Its contents preserve candidate knowledge and provenance; they are not engineering policy.
+
+## Scope
+
+- `sources/` contains one inventory per reviewed source.
+- `decision-ledger.md` consolidates candidates across sources.
+- Canonical standards, reference designs, decision records, and product documentation live outside this directory after review and promotion.
+
+## Evidence labels
+
+- **Confirmed:** Explicitly accepted by the owner.
+- **Corrected:** An earlier proposal was superseded later in the source.
+- **Proposed:** Suggested but not explicitly accepted.
+- **Observed:** Factual or contextual material that is not itself a decision.
+- **Unresolved:** Requires owner review or supporting evidence.
+
+## Required source entry fields
+
+Every candidate decision records:
+
+- a stable source-local ID;
+- a concise statement;
+- its evidence label;
+- source evidence or conversational context;
+- a proposed classification;
+- conflicts, corrections, or dependencies when applicable.
+
+## Classification vocabulary
+
+- Project or governance principle
+- Engineering standard
+- Reference design
+- Design decision
+- Platform, model, or voicing documentation
+- Serialized-instrument documentation
+- Listening note
+- Unresolved question
+- Discussion only
+
+## Promotion rule
+
+Extraction is not adoption. A candidate becomes authoritative only through an explicitly reviewed change to its canonical destination. Promotion must preserve a link back to the source inventory.
+
+## Editing rules
+
+- Preserve the source's terminology during extraction.
+- Separate cross-product conventions from product-specific facts.
+- Record contradictions and corrections instead of silently choosing one.
+- Do not infer owner approval from an assistant's confidence.
+- Do not delete source inventories merely because their contents have been promoted.
+```
+
+- [ ] **Step 2: Verify required boundaries and vocabulary**
+
+Run:
+
+```bash
+rg -n "not engineering policy|Confirmed|Corrected|Proposed|Observed|Unresolved|Extraction is not adoption|Preserve the source's terminology" docs/engineering/extraction/README.md
+```
+
+Expected: every phrase appears once in the relevant section, and all five evidence labels are defined.
+
+- [ ] **Step 3: Check Markdown and whitespace**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit status 0.
+
+- [ ] **Step 4: Commit the staging-area contract**
+
+```bash
+git add docs/engineering/extraction/README.md
+git commit -m "docs: define engineering knowledge extraction"
+```
+
+### Task 2: Inventory the reviewed conversation
+
+**Files:**
+- Create: `docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md`
+
+**Interfaces:**
+- Consumes: Evidence labels and classifications from `docs/engineering/extraction/README.md`; the reviewed shared conversation; boundaries from the approved design spec.
+- Produces: Source-local candidate IDs `ZGDC-001` through `ZGDC-032`, referenced by the decision ledger in Task 3.
+
+- [ ] **Step 1: Add source metadata and extraction notes**
+
+Begin the source inventory with:
+
+```markdown
+# Zebrawood Guitar Documentation Conversation — Decision Inventory
+
+## Source
+
+- **Title:** Zebrawood Guitar Finish Tips
+- **Shared conversation:** <https://chatgpt.com/share/6a6c1c84-dd40-83e8-9c10-42f2d7d2ffe6>
+- **Reviewed:** 2026-07-30
+- **Scope:** Guitar wiring-documentation conventions, engineering-knowledge governance, reusable harness documentation, and transfer of durable decisions from AI conversations into the repository.
+
+## Extraction notes
+
+- This inventory records durable candidates; it does not make them policy.
+- Repeated owner replies of “Agreed” confirm the immediately preceding proposal unless a later correction supersedes it.
+- The conversation also contains product-specific zebrawood construction and wiring decisions. Those are excluded from cross-product candidates and summarized separately as product-specific observations.
+- ChatGPT first claimed that arbitrary agents could inherit saved memory, then corrected that claim. The corrected conclusion is that repository artifacts—not AI memory—must carry shared knowledge.
+```
+
+- [ ] **Step 2: Add confirmed project and governance candidates**
+
+Add entries `ZGDC-001` through `ZGDC-008`. Each entry must use subheadings `Statement`, `Evidence`, `Proposed classification`, and `Notes`.
+
+| ID | Statement | Evidence | Proposed classification |
+|---|---|---|---|
+| ZGDC-001 | The repository, rather than an AI's memory or conversation history, is the authoritative shared knowledge source. | Confirmed | Project or governance principle |
+| ZGDC-002 | Durable decisions should become versioned artifacts rather than memories. | Confirmed | Project or governance principle |
+| ZGDC-003 | The repository should preserve engineering intent—the reason behind a design—not only schematics, bills of materials, and procedures. | Confirmed | Project or governance principle |
+| ZGDC-004 | Begin with industry-standard practice and require a strong justification for deviations. | Confirmed | Project or governance principle |
+| ZGDC-005 | Preserve an instrument's musical personality over theoretical optimization. | Confirmed | Project or governance principle |
+| ZGDC-006 | Favor controls that behave intuitively and as a player expects. | Confirmed | Project or governance principle |
+| ZGDC-007 | Validate designs through both measurement and listening. | Confirmed | Project or governance principle |
+| ZGDC-008 | New durable knowledge should be classified and proposed for an appropriate repository artifact instead of remaining tribal knowledge. | Confirmed | Project or governance principle |
+
+For every `Notes` subsection, explain whether the candidate is cross-product and identify any dependency. `ZGDC-008` must note that not every conversation requires promotion.
+
+- [ ] **Step 3: Add confirmed documentation and drawing candidates**
+
+Add entries `ZGDC-009` through `ZGDC-020` using the same four subheadings.
+
+| ID | Statement | Evidence | Proposed classification |
+|---|---|---|---|
+| ZGDC-009 | Every wiring package begins with design intent and musical goals before implementation detail. | Confirmed | Engineering standard |
+| ZGDC-010 | A wiring specification describes what the design is; a separate assembly guide describes how to build it. | Confirmed | Engineering standard |
+| ZGDC-011 | Electrical schematics use conventional notation and optimize for understanding circuit operation rather than physical assembly. | Confirmed | Engineering standard |
+| ZGDC-012 | Harness layouts use a top view of the control cavity and show physical component placement, routing, and wire identifiers. | Confirmed | Engineering standard |
+| ZGDC-013 | Individual pot diagrams use the canonical bottom view, looking directly at the solder lugs with the lugs facing the reader. | Confirmed | Engineering standard |
+| ZGDC-014 | Component drawings are never mirrored to match a particular installation. | Confirmed | Engineering standard |
+| ZGDC-015 | Prefer positional pot-lug language tied to the explicit viewing convention when numeric lug conventions could be ambiguous. | Confirmed | Engineering standard |
+| ZGDC-016 | Name wires consistently so assembly and debugging can trace each connection. | Confirmed | Engineering standard |
+| ZGDC-017 | Use one concept per figure or page, minimize crossed wires, provide white space and large labels, and make bench documents printable on US Letter without scaling. | Confirmed | Engineering standard |
+| ZGDC-018 | Wiring packages include overview, schematic, harness layout, component details, grounding, assembly sequence, validation, revision history, and design intent. | Confirmed | Engineering standard |
+| ZGDC-019 | Validation includes output-jack resistance ranges, continuity checks, tap tests, expected control behavior, and useful failure-mode guidance. | Confirmed | Engineering standard |
+| ZGDC-020 | Post-build listening notes record surprises, possible changes, strengths, useful settings or playing contexts, and compatible future modifications. | Confirmed | Listening note |
+
+`ZGDC-013` must cite the correction sequence in which the first generated view was reversed, the owner clarified “with the lugs facing you,” and the final wording was accepted. `ZGDC-015` must state that the exact balance between positional and numeric identifiers remains subject to the eventual drawing standard.
+
+- [ ] **Step 4: Add reusable-design and lifecycle candidates**
+
+Add entries `ZGDC-021` through `ZGDC-027` using the same four subheadings.
+
+| ID | Statement | Evidence | Proposed classification |
+|---|---|---|---|
+| ZGDC-021 | Reusable wiring designs receive canonical identities and explicit revisions. | Confirmed | Reference design |
+| ZGDC-022 | Product or instrument documentation identifies the exact reference-design revision used rather than duplicating the entire design. | Confirmed | Engineering standard |
+| ZGDC-023 | Standards contain stable cross-product rules; reusable solutions belong in reference designs; consequential rationale belongs in decision records; product discoveries belong in product documentation or listening notes. | Confirmed | Project or governance principle |
+| ZGDC-024 | Standards distinguish requirements, recommendations, and examples so an example is not mistaken for a rule. | Confirmed | Engineering standard |
+| ZGDC-025 | Significant decisions record status, context, decision, consequences, and references. | Confirmed | Engineering standard |
+| ZGDC-026 | Candidate knowledge may move through Draft, Experimental, Validated, Approved, and Deprecated states. | Confirmed | Unresolved question |
+| ZGDC-027 | Engineering learning follows an observe, experiment, measure, listen, decide, document, reuse, and teach cycle. | Confirmed | Project or governance principle |
+
+`ZGDC-021` must not adopt the conversation's example `RL-HAR-*` identifiers as policy. `ZGDC-026` must explain that the lifecycle concept was accepted but the exact applicability and transition rules remain unresolved.
+
+- [ ] **Step 5: Record corrected, proposed, and unresolved repository-structure candidates**
+
+Add entries `ZGDC-028` through `ZGDC-032` using the same four subheadings.
+
+| ID | Statement | Evidence | Proposed classification |
+|---|---|---|---|
+| ZGDC-028 | Harvest conversations into persistent intermediate artifacts before designing or populating the final knowledge hierarchy. | Corrected | Project or governance principle |
+| ZGDC-029 | Preserve one source inventory per conversation and maintain a consolidated decision ledger. | Confirmed | Project or governance principle |
+| ZGDC-030 | Use small, reviewable changes for extraction, governance, standards, templates, and migration rather than one large refactor. | Confirmed | Project or governance principle |
+| ZGDC-031 | Create separate top-level engineering and products hierarchies matching the examples in the conversation. | Proposed | Unresolved question |
+| ZGDC-032 | Add a separate root `AI_CONTRIBUTING.md` as the universal agent entry point. | Proposed | Unresolved question |
+
+`ZGDC-028` must preserve the correction: the conversation first recommended building repository governance before harvesting, then reversed that advice after the owner identified the risk of losing decisions. `ZGDC-031` and `ZGDC-032` must note the current repository structures that make literal adoption inappropriate without further review.
+
+- [ ] **Step 6: Add product-specific observations and explicit exclusions**
+
+Add a `## Product-specific observations` section stating that the source contains zebrawood-build facts and candidate wiring choices—including Mini ProBucker measurements, independent volumes, treble-bleed values, partial-split proposals, finish advice, and weight decisions—but these are not extracted as cross-product standards in this phase.
+
+Add a `## Explicit exclusions` section listing:
+
+- generated images, diagrams, and sandbox download links that are not durable repository assets;
+- assistant predictions about how the guitar will sound or which settings the owner will prefer;
+- implementation examples not explicitly accepted as naming or directory policy;
+- private ChatGPT memory operations that cannot provide repository-wide agent instructions.
+
+- [ ] **Step 7: Verify inventory completeness and labels**
+
+Run:
+
+```bash
+for id in {001..032}; do rg -q "ZGDC-${id}" docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md || exit 1; done
+```
+
+Expected: exit status 0.
+
+Run:
+
+```bash
+rg -c '^### ZGDC-' docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md
+```
+
+Expected: `32`.
+
+Run:
+
+```bash
+rg -n '^\*\*Evidence:\*\* (Confirmed|Corrected|Proposed|Observed|Unresolved)$' docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md
+```
+
+Expected: 32 matching lines, one for each candidate.
+
+- [ ] **Step 8: Check Markdown and commit the source inventory**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit status 0.
+
+```bash
+git add docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md
+git commit -m "docs: inventory guitar documentation decisions"
+```
+
+### Task 3: Create the consolidated decision ledger
+
+**Files:**
+- Create: `docs/engineering/extraction/decision-ledger.md`
+
+**Interfaces:**
+- Consumes: Candidate IDs `ZGDC-001` through `ZGDC-032` and their evidence/classification fields from Task 2.
+- Produces: The review and consolidation index future source inventories and promotion work will update.
+
+- [ ] **Step 1: Create the ledger overview and status vocabulary**
+
+Begin the ledger with:
+
+```markdown
+# Engineering Decision Ledger
+
+This ledger consolidates candidate knowledge from reviewed sources. It is an extraction index, not an engineering standard. Canonical documents become authoritative only after explicit review and promotion.
+
+## Ledger status
+
+- **Awaiting review:** Extracted but not yet accepted for promotion.
+- **Needs resolution:** A correction, conflict, classification, or terminology question requires owner input.
+- **Ready to promote:** Reviewed and assigned to a canonical destination.
+- **Promoted:** Incorporated into a canonical artifact with a recorded destination.
+- **Not promoted:** Reviewed and intentionally retained only as source context.
+
+## Sources
+
+- [ZGDC — Zebrawood Guitar Documentation Conversation](sources/2026-07-30-zebrawood-guitar-documentation-conversation.md)
+```
+
+- [ ] **Step 2: Add the candidate table**
+
+Add `## Candidates` with a table containing exactly these columns:
+
+```markdown
+| Candidate | Summary | Evidence | Proposed classification | Ledger status | Canonical destination |
+|---|---|---|---|---|---|
+```
+
+Add one row for every candidate `ZGDC-001` through `ZGDC-032`. Link each candidate ID to its anchor in the source inventory. Use the source statement in shortened form without changing its meaning.
+
+Set ledger statuses as follows:
+
+- `Needs resolution`: `ZGDC-015`, `ZGDC-026`, `ZGDC-031`, and `ZGDC-032`.
+- `Awaiting review`: all other candidates.
+- `Canonical destination`: `—` for every row in this phase.
+
+- [ ] **Step 3: Add consolidation and open-question sections**
+
+Add these sections after the table:
+
+```markdown
+## Consolidation notes
+
+- ZGDC-001, ZGDC-002, and ZGDC-003 overlap but are not duplicates: they separately establish authority, artifact persistence, and preservation of rationale.
+- ZGDC-009 through ZGDC-020 are likely to inform one guitar-documentation standard, but no standard exists yet.
+- ZGDC-021 and ZGDC-022 distinguish reusable design identity from a product's declaration of the revision it uses.
+- ZGDC-023 defines classification boundaries and should be reconciled with the repository's existing content terminology before promotion.
+- ZGDC-028 supersedes the earlier sequence that designed governance before harvesting conversations.
+
+## Open questions
+
+1. Should eventual documents use ES/RD/DD identifiers, descriptive filenames, or both?
+2. Should positional pot-lug names supplement or replace numeric lug identifiers?
+3. Which lifecycle states apply to standards, reference designs, decisions, and product documentation, and what transitions require owner approval?
+4. How should “model,” “voicing,” “platform,” “product,” and “serialized instrument” be defined without disrupting existing site terminology?
+5. Should the existing `AGENTS.md` and `CLAUDE.md` point to a shared engineering front door, avoiding a separate `AI_CONTRIBUTING.md`?
+6. Which zebrawood wiring decisions belong in a future product record, reference design, or serialized-instrument record?
+
+## Promotion log
+
+No candidates have been promoted.
+```
+
+- [ ] **Step 4: Verify ledger coverage and unresolved statuses**
+
+Run:
+
+```bash
+for id in {001..032}; do rg -q "ZGDC-${id}" docs/engineering/extraction/decision-ledger.md || exit 1; done
+```
+
+Expected: exit status 0.
+
+Run:
+
+```bash
+rg -c '^\| \[ZGDC-' docs/engineering/extraction/decision-ledger.md
+```
+
+Expected: `32`.
+
+Run:
+
+```bash
+rg '^\| \[ZGDC-(015|026|031|032)\].*\| Needs resolution \| — \|$' docs/engineering/extraction/decision-ledger.md
+```
+
+Expected: four matching rows.
+
+- [ ] **Step 5: Verify phase boundaries**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only the three files named in Global Constraints are new or modified during implementation.
+
+Run:
+
+```bash
+find docs/engineering -type f | sort
+```
+
+Expected:
+
+```text
+docs/engineering/extraction/README.md
+docs/engineering/extraction/decision-ledger.md
+docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md
+```
+
+- [ ] **Step 6: Check Markdown and commit the ledger**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit status 0.
+
+```bash
+git add docs/engineering/extraction/decision-ledger.md
+git commit -m "docs: add engineering decision ledger"
+```
+
+### Task 4: Final extraction audit
+
+**Files:**
+- Verify: `docs/engineering/extraction/README.md`
+- Verify: `docs/engineering/extraction/decision-ledger.md`
+- Verify: `docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md`
+
+**Interfaces:**
+- Consumes: All artifacts from Tasks 1 through 3.
+- Produces: A verified extraction phase ready for owner review, not automatic promotion.
+
+- [ ] **Step 1: Verify no placeholders or deferred implementation language**
+
+Run:
+
+```bash
+rg -n 'T[B]D|T[O]DO|PLACEH[O]LDER|fill i[n]|implement late[r]|similar to Tas[k]' docs/engineering/extraction
+```
+
+Expected: no output and exit status 1 because no prohibited placeholders exist.
+
+- [ ] **Step 2: Verify source-to-ledger traceability**
+
+Run:
+
+```bash
+for id in {001..032}; do rg -q "^### ZGDC-${id}" docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md && rg -q "\[ZGDC-${id}\]" docs/engineering/extraction/decision-ledger.md || exit 1; done
+```
+
+Expected: exit status 0.
+
+- [ ] **Step 3: Verify prohibited repository areas are unchanged by this phase**
+
+Run:
+
+```bash
+git diff HEAD~3 --name-only
+```
+
+Expected: exactly the three extraction files. If the execution started with unrelated user changes or a different commit count, compare against the implementation starting commit instead and confirm that this plan changed only the three permitted paths.
+
+- [ ] **Step 4: Review the rendered content manually**
+
+Read all three files in order:
+
+1. `docs/engineering/extraction/README.md`
+2. `docs/engineering/extraction/sources/2026-07-30-zebrawood-guitar-documentation-conversation.md`
+3. `docs/engineering/extraction/decision-ledger.md`
+
+Confirm:
+
+- the README never describes extracted candidates as policy;
+- all 32 source entries are understandable without opening the original chat;
+- corrected advice is visibly marked rather than silently replaced;
+- product-specific details are not generalized into standards;
+- the ledger's four `Needs resolution` entries and six open questions are explicit;
+- no canonical destination is assigned prematurely.
+
+- [ ] **Step 5: Record the verified state**
+
+Run:
+
+```bash
+git status --short
+git log -3 --oneline
+```
+
+Expected: a clean working tree and three focused extraction commits, one for each artifact boundary.
+
+Do not promote any candidate or create any additional file until the owner reviews the extraction artifacts.

--- a/docs/superpowers/specs/2026-07-30-guitar-engineering-knowledge-design.md
+++ b/docs/superpowers/specs/2026-07-30-guitar-engineering-knowledge-design.md
@@ -1,0 +1,212 @@
+# Guitar Engineering Knowledge System
+
+## Purpose
+
+Create a durable, tool-independent knowledge system for documenting K7RHY guitar models and their supporting engineering work. The repository—not an AI conversation or an agent's memory—will be the authoritative source.
+
+The first implementation phase is knowledge extraction. It will preserve decisions from prior conversations as reviewable intermediate artifacts before those decisions are promoted into standards, reference designs, decision records, or published model documentation.
+
+## Existing Context
+
+The repository already separates several kinds of guitar content:
+
+- `content/coupeville/models/` describes Coupeville models.
+- `content/relay/voicings/` describes Relay voicings.
+- `content/relay/wiring/` contains Relay wiring documentation.
+- `content/instruments/` contains permanent, unlisted serial-number records.
+- `docs/architecture/site-organization.md` governs public information architecture, commerce boundaries, and serialized instruments.
+- `AGENTS.md` and `CLAUDE.md` provide tool-specific repository instructions.
+
+The knowledge system must complement these structures rather than replace them with a competing product hierarchy.
+
+## Design Principles
+
+1. The repository is the source of truth.
+2. Preserve engineering intent, not only finished artifacts.
+3. Extract knowledge before designing its final classification and location.
+4. Separate durable rules from examples and product-specific values.
+5. Reference reusable knowledge instead of duplicating it.
+6. Keep published site content separate from internal engineering governance.
+7. Prefer small, reviewable changes over a large documentation migration.
+8. Do not invent policy when evidence is incomplete; record an open question instead.
+
+## Proposed Structure
+
+```text
+docs/
+├── architecture/
+│   └── site-organization.md
+└── engineering/
+    ├── README.md
+    ├── guitar-documentation-standard.md
+    ├── knowledge-index.md
+    ├── decisions/
+    ├── reference-designs/
+    ├── templates/
+    └── extraction/
+        ├── decision-ledger.md
+        └── sources/
+```
+
+This is the target shape, not the scope of the first implementation. Directories should be added only when they have reviewed content to contain.
+
+### Automatically discovered instructions
+
+`AGENTS.md` and `CLAUDE.md` remain the entry points for their respective agents. Once the canonical engineering documents exist, both files will point to the same shared instructions rather than duplicate those instructions in tool-specific prose.
+
+Do not add a third root-level AI contribution guide unless a later need cannot be met by this arrangement.
+
+### Engineering front door
+
+`docs/engineering/README.md` will define:
+
+- the purpose and scope of the engineering knowledge system;
+- the authority order between standards, decisions, reference designs, and product records;
+- the classification workflow for new knowledge;
+- how exceptions are documented;
+- terminology shared by agents and human contributors.
+
+### Knowledge index
+
+`docs/engineering/knowledge-index.md` will map each engineering topic to its authoritative source. It is a navigation aid, not another copy of the underlying documentation.
+
+### Engineering standards
+
+Standards contain stable, cross-product requirements and recommendations. Product-specific electrical values, example harnesses, and historical rationale do not belong in a standard.
+
+The initial guitar documentation standard is expected to include the decisions confirmed in the reviewed conversation:
+
+- design intent precedes implementation;
+- wiring specifications are separate from assembly guides;
+- diagrams use explicit, consistent viewing conventions;
+- pot details use a canonical bottom view, looking directly at the solder lugs with the lugs facing the reader;
+- component drawings are never mirrored for a particular installation;
+- harness layouts use a top view of the control cavity;
+- electrical schematics use conventional electronic notation;
+- figures favor one concept per page, clear wire names, readable labels, white space, and printable service-manual presentation;
+- wiring packages cover design intent, overview, specification, schematic, harness layout, component details, grounding, assembly, validation, revision history, and listening notes.
+
+### Reference designs
+
+Reference designs describe reusable, revisioned engineering solutions such as a validated wiring harness. A product or serialized instrument may identify the exact reference-design revision it uses without copying the full design.
+
+### Decision records
+
+Decision records preserve consequential rationale: context, decision, consequences, status, and references. They explain why a choice was made without turning that choice into a universal rule.
+
+### Published content
+
+Public model, voicing, wiring, and instrument content remains in the existing `content/` hierarchy. Its terminology and routes must continue to follow `docs/architecture/site-organization.md`.
+
+## Knowledge Classification
+
+When durable knowledge is discovered, classify it as one of:
+
+- project or governance principle;
+- engineering standard;
+- reference design;
+- design decision;
+- platform, model, or voicing documentation;
+- serialized-instrument documentation;
+- listening note;
+- unresolved question;
+- discussion only, requiring no repository artifact.
+
+Classification is a proposal during extraction. Promotion into a canonical document requires review.
+
+## Extraction Artifacts
+
+The first implementation phase creates only the extraction area and the inventory for the reviewed ChatGPT conversation.
+
+Each source inventory should include:
+
+- source title, date, and stable link when available;
+- scope and provenance;
+- individually identifiable candidate decisions;
+- the evidence level for each decision;
+- proposed classification;
+- conflicts, corrections, duplicates, and open questions;
+- product-specific facts kept separate from cross-product conventions.
+
+Use these evidence labels:
+
+- **Confirmed:** explicitly accepted by the owner.
+- **Corrected:** an earlier proposal was superseded later in the conversation.
+- **Proposed:** suggested by an assistant but not explicitly accepted.
+- **Observed:** factual or contextual material that may inform documentation but is not a decision.
+- **Unresolved:** requires owner review or supporting evidence.
+
+The decision ledger summarizes the source inventories and tracks consolidation. It must link back to the source inventory so provenance is not lost.
+
+Extraction files are persistent intermediate artifacts. Their eventual retention or archival will be decided after migration; they should not be deleted merely because Git history contains an earlier copy.
+
+## Authority Order
+
+Agents should consult documents in this order when the task concerns guitar engineering documentation:
+
+1. `AGENTS.md` or `CLAUDE.md`
+2. `docs/architecture/site-organization.md` when its stated scope applies
+3. `docs/engineering/README.md`
+4. `docs/engineering/knowledge-index.md`
+5. applicable engineering standards
+6. applicable reference designs and decision records
+7. platform, model, voicing, wiring, or serialized-instrument content
+
+A lower-level artifact may depart from a standard only when the exception and its rationale are explicit.
+
+## Migration Sequence
+
+1. Create the extraction directory, a decision ledger, and an inventory for the reviewed conversation.
+2. Review existing Coupeville, Relay, wiring, and serialized-instrument content against that inventory.
+3. Harvest additional conversations one at a time.
+4. Consolidate duplicates, corrections, conflicts, and terminology questions.
+5. Approve the final engineering-document architecture based on the harvested knowledge.
+6. Add the engineering front door and knowledge index.
+7. Promote stable rules into the guitar documentation standard.
+8. Add decision records, reference designs, and templates only as needed.
+9. Update `AGENTS.md` and `CLAUDE.md` once their canonical targets exist.
+10. Migrate or cross-reference existing product-facing documentation incrementally.
+
+## Risks and Mitigations
+
+### Premature structure
+
+Creating a complete hierarchy before extraction may force knowledge into unsuitable categories. Mitigation: implement only the extraction layer first.
+
+### Duplicate authority
+
+Repeating shared policy in `AGENTS.md`, `CLAUDE.md`, standards, and published content would create drift. Mitigation: keep tool-specific entry points short and link to canonical shared documents.
+
+### Terminology conflicts
+
+The conversation used “model,” “product,” “platform,” and “reference harness” loosely, while the repository distinguishes Coupeville models, Relay voicings, and serialized instruments. Mitigation: preserve current terms during extraction and resolve them before migration.
+
+### Treating examples as requirements
+
+Example component values and example directory names could be mistaken for standards. Mitigation: label examples and keep product-specific values out of standards.
+
+### Documentation churn
+
+Requiring an artifact after every conversation could create low-value files. Mitigation: promote only durable knowledge; discussion may remain discussion.
+
+## Validation
+
+The extraction phase is successful when:
+
+- every durable decision in the reviewed conversation has a traceable inventory entry;
+- confirmations, corrections, proposals, and unresolved questions are distinguishable;
+- no published content or route has been reorganized;
+- no candidate decision has silently become policy;
+- another agent can understand what was decided without reopening the original conversation.
+
+The completed knowledge system is successful when an agent can locate the authoritative guidance for a new guitar model, create documentation using the agreed conventions, reuse validated designs, and preserve new rationale without relying on private AI memory.
+
+## Initial Implementation Boundary
+
+The next implementation plan must cover only:
+
+- `docs/engineering/extraction/decision-ledger.md`;
+- one source inventory for the reviewed ChatGPT conversation; and
+- only the minimum directory documentation needed to explain that staging area.
+
+It must not yet create standards, reference designs, templates, governance documents, or changes to `AGENTS.md` and `CLAUDE.md`.


### PR DESCRIPTION
## Summary
- add a persistent engineering-knowledge extraction staging area and decision ledger
- inventory four ChatGPT conversations covering guitar documentation governance, Coupeville Velvet, Coupeville Current, and Coupeville Reef
- catalog 101 traceable candidates with confirmations, corrections, proposals, observations, and unresolved questions
- preserve model decisions for later model-page improvements without promoting candidates into policy

## Important review boundary
This PR records extracted knowledge and provenance only. It does not create engineering standards, promote decisions, modify model pages, or change agent instructions. Decision review and promotion will happen after merge.

## Verification
- `npx vitest run` — 51 test files, 214 tests passed
- source-to-ledger traceability verified for all 101 candidates
- `git diff --check` passed